### PR TITLE
R10 multiread for `next_key`

### DIFF
--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -28,6 +28,7 @@ impl<'buf> Buffer<'buf> {
         n_new_bytes
     }
 
+    #[allow(clippy::missing_panics_doc)]
     pub fn read_more_to_pos(&mut self, start_index: usize) -> usize {
         let n_new_bytes = self.reader.read(&mut self.buf[start_index..]).unwrap();
         self.n_bytes += n_new_bytes;

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -36,11 +36,12 @@ impl<'buf> Buffer<'buf> {
 
     #[allow(clippy::missing_panics_doc)]
     pub fn shift_buffer(&mut self, to_pos: usize, from_pos: usize) {
-        if from_pos > to_pos {
+        if from_pos > to_pos && to_pos < self.n_bytes {
             if from_pos < self.n_bytes {
                 self.buf.copy_within(from_pos..self.n_bytes, to_pos);
             }
-            let n_shifted_out = min(from_pos - to_pos, self.n_bytes);
+            let from_pos = min(from_pos, self.n_bytes);
+            let n_shifted_out = from_pos - to_pos;
             self.n_bytes -= n_shifted_out;
             self.n_shifted_out += n_shifted_out;
         }

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -1,0 +1,50 @@
+use std::io::Read;
+
+pub(crate) struct Buffer<'buf> {
+    reader: &'buf mut dyn Read,
+    pub buffer: &'buf mut [u8],
+    pub bytes_in_buffer: usize,
+}
+
+impl<'buf> Buffer<'buf> {
+    pub fn new(reader: &'buf mut dyn Read, buffer: &'buf mut [u8]) -> Self {
+        let bytes_in_buffer = reader.read(buffer).unwrap();
+        
+        Buffer {
+            reader,
+            buffer,
+            bytes_in_buffer,
+        }
+    }
+
+    pub fn read_more(&mut self, start_index: usize) -> usize {
+        let n_new_bytes = self.reader.read(&mut self.buffer[start_index..]).unwrap();
+        self.bytes_in_buffer = start_index + n_new_bytes;
+        n_new_bytes
+    }
+
+    pub fn shift_buffer(&mut self, pos: usize, is_partial_string: bool) {
+        if pos > 0 {
+            if pos < self.bytes_in_buffer {
+                assert!(
+                    !is_partial_string,
+                    "Buffer should be completely consumed in partial string case"
+                );
+
+                self.buffer.copy_within(pos..self.bytes_in_buffer, 0);
+                self.bytes_in_buffer -= pos;
+            } else {
+                self.bytes_in_buffer = 0;
+            }
+        }
+    }
+}
+impl<'buf> std::fmt::Debug for Buffer<'buf> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f,
+            "Buffer {{ bytes_in_buffer: {:?}, buffer: {:?} }}",
+            self.bytes_in_buffer,
+            self.buffer
+        )
+    }
+}

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -45,8 +45,8 @@ impl<'buf> Buffer<'buf> {
             i += 1;
         }
         if i > pos {
-            self.buf.copy_within(i..self.n_bytes, 0);
-            self.n_bytes -= i;
+            self.buf.copy_within(i..self.n_bytes, pos);
+            self.n_bytes -= i - pos;
         }
     }
 }

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -1,5 +1,5 @@
-use std::io::Read;
 use std::cmp::min;
+use std::io::Read;
 
 pub struct Buffer<'buf> {
     reader: &'buf mut dyn Read,

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -40,8 +40,14 @@ impl<'buf> Buffer<'buf> {
     }
 
     pub fn skip_spaces(&mut self, pos: usize) {
-
-        println!("Buffer::skip_spaces: pos: {:?}", pos); // FIXME
+        let mut i = pos;
+        while i < self.n_bytes && self.buf[i].is_ascii_whitespace() {
+            i += 1;
+        }
+        if i > pos {
+            self.buf.copy_within(i..self.n_bytes, 0);
+            self.n_bytes -= i;
+        }
     }
 }
 

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -73,8 +73,8 @@ impl<'buf> std::fmt::Debug for Buffer<'buf> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Buffer {{ n_bytes: {:?}, buf: {:?} }}",
-            self.n_bytes, self.buf
+            "Buffer {{ n_bytes: {:?}, n_shifted_out: {:?}, buf: {:?} }}",
+            self.n_bytes, self.n_shifted_out, self.buf
         )
     }
 }

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -1,4 +1,5 @@
 use std::io::Read;
+use std::cmp::min;
 
 pub struct Buffer<'buf> {
     reader: &'buf mut dyn Read,
@@ -35,16 +36,13 @@ impl<'buf> Buffer<'buf> {
 
     #[allow(clippy::missing_panics_doc)]
     pub fn shift_buffer(&mut self, to_pos: usize, from_pos: usize) {
-        if from_pos > to_pos && from_pos < self.n_bytes {
-            self.buf.copy_within(from_pos..self.n_bytes, to_pos);
-            let n_shifted_out = from_pos - to_pos;
+        if from_pos > to_pos {
+            if from_pos < self.n_bytes {
+                self.buf.copy_within(from_pos..self.n_bytes, to_pos);
+            }
+            let n_shifted_out = min(from_pos - to_pos, self.n_bytes);
             self.n_bytes -= n_shifted_out;
             self.n_shifted_out += n_shifted_out;
-        } else {
-            if from_pos > to_pos {
-                self.n_shifted_out += from_pos - to_pos;
-            }
-            self.n_bytes = to_pos;
         }
     }
 

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -2,49 +2,49 @@ use std::io::Read;
 
 pub(crate) struct Buffer<'buf> {
     reader: &'buf mut dyn Read,
-    pub buffer: &'buf mut [u8],
-    pub bytes_in_buffer: usize,
+    pub buf: &'buf mut [u8],
+    pub n_bytes: usize,
 }
 
 impl<'buf> Buffer<'buf> {
-    pub fn new(reader: &'buf mut dyn Read, buffer: &'buf mut [u8]) -> Self {
-        let bytes_in_buffer = reader.read(buffer).unwrap();
-        
+    pub fn new(reader: &'buf mut dyn Read, buf: &'buf mut [u8]) -> Self {
+        let n_bytes = reader.read(buf).unwrap();
+
         Buffer {
             reader,
-            buffer,
-            bytes_in_buffer,
+            buf,
+            n_bytes,
         }
     }
 
     pub fn read_more(&mut self, start_index: usize) -> usize {
-        let n_new_bytes = self.reader.read(&mut self.buffer[start_index..]).unwrap();
-        self.bytes_in_buffer = start_index + n_new_bytes;
+        let n_new_bytes = self.reader.read(&mut self.buf[start_index..]).unwrap();
+        self.n_bytes = start_index + n_new_bytes;
         n_new_bytes
     }
 
     pub fn shift_buffer(&mut self, pos: usize, is_partial_string: bool) {
         if pos > 0 {
-            if pos < self.bytes_in_buffer {
+            if pos < self.n_bytes {
                 assert!(
                     !is_partial_string,
                     "Buffer should be completely consumed in partial string case"
                 );
 
-                self.buffer.copy_within(pos..self.bytes_in_buffer, 0);
-                self.bytes_in_buffer -= pos;
+                self.buf.copy_within(pos..self.n_bytes, 0);
+                self.n_bytes -= pos;
             } else {
-                self.bytes_in_buffer = 0;
+                self.n_bytes = 0;
             }
         }
     }
 }
 impl<'buf> std::fmt::Debug for Buffer<'buf> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f,
-            "Buffer {{ bytes_in_buffer: {:?}, buffer: {:?} }}",
-            self.bytes_in_buffer,
-            self.buffer
+        write!(
+            f,
+            "Buffer {{ n_bytes: {:?}, buf: {:?} }}",
+            self.n_bytes, self.buf
         )
     }
 }

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -7,6 +7,7 @@ pub struct Buffer<'buf> {
 }
 
 impl<'buf> Buffer<'buf> {
+    #[allow(clippy::missing_panics_doc)]
     pub fn new(reader: &'buf mut dyn Read, buf: &'buf mut [u8]) -> Self {
         let n_bytes = reader.read(buf).unwrap();
 
@@ -17,12 +18,14 @@ impl<'buf> Buffer<'buf> {
         }
     }
 
+    #[allow(clippy::missing_panics_doc)]
     pub fn read_more(&mut self, start_index: usize) -> usize {
         let n_new_bytes = self.reader.read(&mut self.buf[start_index..]).unwrap();
         self.n_bytes += n_new_bytes;
         n_new_bytes
     }
 
+    #[allow(clippy::missing_panics_doc)]
     pub fn shift_buffer(&mut self, pos: usize, is_partial_string: bool) {
         if pos > 0 {
             if pos < self.n_bytes {

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -20,36 +20,50 @@ impl<'buf> Buffer<'buf> {
 
     #[allow(clippy::missing_panics_doc)]
     pub fn read_more(&mut self, start_index: usize) -> usize {
+        println!("Buffer::read_more before read: reading to the buffer: {:?}", &self.buf[start_index..]); // FIXME
         let n_new_bytes = self.reader.read(&mut self.buf[start_index..]).unwrap();
+        println!("Buffer::read_more after read: n_new_bytes: {:?}", n_new_bytes); // FIXME
         self.n_bytes += n_new_bytes;
         n_new_bytes
     }
 
     #[allow(clippy::missing_panics_doc)]
-    pub fn shift_buffer(&mut self, pos: usize, is_partial_string: bool) {
-        if pos > 0 {
-            if pos < self.n_bytes {
-                assert!(
-                    !is_partial_string,
-                    "Buffer should be completely consumed in partial string case"
-                );
-
-                self.buf.copy_within(pos..self.n_bytes, 0);
-                self.n_bytes -= pos;
-            } else {
-                self.n_bytes = 0;
-            }
+    pub fn shift_buffer(&mut self, to_pos: usize, from_pos: usize) {
+        if from_pos > to_pos && from_pos < self.n_bytes {
+            self.buf.copy_within(from_pos..self.n_bytes, to_pos);
+            self.n_bytes -= from_pos - to_pos;
+        } else {
+            self.n_bytes = to_pos;
         }
     }
 
     pub fn skip_spaces(&mut self, pos: usize) {
         let mut i = pos;
-        while i < self.n_bytes && self.buf[i].is_ascii_whitespace() {
-            i += 1;
-        }
-        if i > pos {
-            self.buf.copy_within(i..self.n_bytes, pos);
-            self.n_bytes -= i - pos;
+        loop {
+            while i < self.n_bytes && self.buf[i].is_ascii_whitespace() {
+                i += 1;
+            }
+            
+            if i < self.n_bytes {
+                // Found non-whitespace
+                if i > pos {
+                    self.shift_buffer(pos, i);
+                }
+                break;
+            }
+            
+            println!("Buffer::skip_space before shift: pos: {:?}, i: {:?}, n_bytes: {:?}", pos, i, self.n_bytes); // FIXME
+
+            // Reached end of buffer, shift and read more
+            self.shift_buffer(pos, self.n_bytes);
+            println!("Buffer::skip_space after shift: pos: {:?}, i: {:?}, n_bytes: {:?}", pos, i, self.n_bytes); // FIXME
+            let n_new = self.read_more(self.n_bytes);
+            println!("Buffer::skip_space after read: pos: {:?}, i: {:?}, n_bytes: {:?}, n_new: {:?}", pos, i, self.n_bytes, n_new); // FIXME
+            if n_new == 0 {
+                // EOF reached
+                break;
+            }
+            i = self.n_bytes - n_new;
         }
     }
 }

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -4,6 +4,7 @@ pub struct Buffer<'buf> {
     reader: &'buf mut dyn Read,
     pub buf: &'buf mut [u8],
     pub n_bytes: usize,
+    pub n_shifted_out: usize,
 }
 
 impl<'buf> Buffer<'buf> {
@@ -15,6 +16,7 @@ impl<'buf> Buffer<'buf> {
             reader,
             buf,
             n_bytes,
+            n_shifted_out: 0,
         }
     }
 
@@ -29,8 +31,13 @@ impl<'buf> Buffer<'buf> {
     pub fn shift_buffer(&mut self, to_pos: usize, from_pos: usize) {
         if from_pos > to_pos && from_pos < self.n_bytes {
             self.buf.copy_within(from_pos..self.n_bytes, to_pos);
-            self.n_bytes -= from_pos - to_pos;
+            let n_shifted_out = from_pos - to_pos;
+            self.n_bytes -= n_shifted_out;
+            self.n_shifted_out += n_shifted_out;
         } else {
+            if from_pos > to_pos {
+                self.n_shifted_out += from_pos - to_pos;
+            }
             self.n_bytes = to_pos;
         }
     }

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -19,7 +19,7 @@ impl<'buf> Buffer<'buf> {
 
     pub fn read_more(&mut self, start_index: usize) -> usize {
         let n_new_bytes = self.reader.read(&mut self.buf[start_index..]).unwrap();
-        self.n_bytes = start_index + n_new_bytes;
+        self.n_bytes += n_new_bytes;
         n_new_bytes
     }
 

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
 
-pub(crate) struct Buffer<'buf> {
+pub struct Buffer<'buf> {
     reader: &'buf mut dyn Read,
     pub buf: &'buf mut [u8],
     pub n_bytes: usize,
@@ -38,7 +38,13 @@ impl<'buf> Buffer<'buf> {
             }
         }
     }
+
+    pub fn skip_spaces(&mut self, pos: usize) {
+
+        println!("Buffer::skip_spaces: pos: {:?}", pos); // FIXME
+    }
 }
+
 impl<'buf> std::fmt::Debug for Buffer<'buf> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -21,7 +21,13 @@ impl<'buf> Buffer<'buf> {
     }
 
     #[allow(clippy::missing_panics_doc)]
-    pub fn read_more(&mut self, start_index: usize) -> usize {
+    pub fn read_more(&mut self) -> usize {
+        let n_new_bytes = self.reader.read(&mut self.buf[self.n_bytes..]).unwrap();
+        self.n_bytes += n_new_bytes;
+        n_new_bytes
+    }
+
+    pub fn read_more_to_pos(&mut self, start_index: usize) -> usize {
         let n_new_bytes = self.reader.read(&mut self.buf[start_index..]).unwrap();
         self.n_bytes += n_new_bytes;
         n_new_bytes
@@ -59,7 +65,7 @@ impl<'buf> Buffer<'buf> {
 
             // Reached end of buffer, shift and read more
             self.shift_buffer(pos, self.n_bytes);
-            let n_new = self.read_more(self.n_bytes);
+            let n_new = self.read_more();
             if n_new == 0 {
                 // EOF reached
                 break;

--- a/rjiter/src/buffer.rs
+++ b/rjiter/src/buffer.rs
@@ -20,9 +20,7 @@ impl<'buf> Buffer<'buf> {
 
     #[allow(clippy::missing_panics_doc)]
     pub fn read_more(&mut self, start_index: usize) -> usize {
-        println!("Buffer::read_more before read: reading to the buffer: {:?}", &self.buf[start_index..]); // FIXME
         let n_new_bytes = self.reader.read(&mut self.buf[start_index..]).unwrap();
-        println!("Buffer::read_more after read: n_new_bytes: {:?}", n_new_bytes); // FIXME
         self.n_bytes += n_new_bytes;
         n_new_bytes
     }
@@ -43,7 +41,7 @@ impl<'buf> Buffer<'buf> {
             while i < self.n_bytes && self.buf[i].is_ascii_whitespace() {
                 i += 1;
             }
-            
+
             if i < self.n_bytes {
                 // Found non-whitespace
                 if i > pos {
@@ -51,14 +49,10 @@ impl<'buf> Buffer<'buf> {
                 }
                 break;
             }
-            
-            println!("Buffer::skip_space before shift: pos: {:?}, i: {:?}, n_bytes: {:?}", pos, i, self.n_bytes); // FIXME
 
             // Reached end of buffer, shift and read more
             self.shift_buffer(pos, self.n_bytes);
-            println!("Buffer::skip_space after shift: pos: {:?}, i: {:?}, n_bytes: {:?}", pos, i, self.n_bytes); // FIXME
             let n_new = self.read_more(self.n_bytes);
-            println!("Buffer::skip_space after read: pos: {:?}, i: {:?}, n_bytes: {:?}, n_new: {:?}", pos, i, self.n_bytes, n_new); // FIXME
             if n_new == 0 {
                 // EOF reached
                 break;

--- a/rjiter/src/lib.rs
+++ b/rjiter/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod rjiter;
+mod buffer;
 
 pub use rjiter::RJiter;
-
 pub use jiter::*;

--- a/rjiter/src/lib.rs
+++ b/rjiter/src/lib.rs
@@ -1,5 +1,5 @@
-pub mod rjiter;
 mod buffer;
+pub mod rjiter;
 
-pub use rjiter::RJiter;
 pub use jiter::*;
+pub use rjiter::RJiter;

--- a/rjiter/src/lib.rs
+++ b/rjiter/src/lib.rs
@@ -1,4 +1,4 @@
-mod buffer;
+pub mod buffer;
 pub mod rjiter;
 
 pub use jiter::*;

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -172,7 +172,9 @@ impl<'rj> RJiter<'rj> {
                 error_type:
                     JiterErrorType::JsonError(
                         ref error_type @ (JsonErrorType::EofWhileParsingString
-                        | JsonErrorType::ExpectedObjectCommaOrEnd),
+                        | JsonErrorType::ExpectedObjectCommaOrEnd
+                        | JsonErrorType::EofWhileParsingObject)
+                        ,
                     ),
                 ..
             } = error

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -150,19 +150,23 @@ impl<'rj> RJiter<'rj> {
         self.jiter.next_int()
     }
 
+    fn shutup_borrow_checker(result: Option<&str>) -> Option<&'rj str> {
+        match result {
+            Some(key) => {
+                let key_2 = unsafe { std::mem::transmute::<&str, &'rj str>(key) };
+                Some(key_2)
+            }
+            None => None
+        }
+    }
+
     #[allow(clippy::missing_errors_doc)]
     pub fn next_key(&mut self) -> JiterResult<Option<&str>> {
-         let result = self.jiter.next_key();
-         if result.is_ok() {
-            let key = result.unwrap();
-            if !key.is_some() {
-                return Ok(None);
-            }
-            let key = key.unwrap();
-            let key_2 = unsafe { std::mem::transmute::<&str, &'rj str>(key) };
-            return Ok(Some(key_2));
-         }
-         self.jiter.next_key()
+        let result = self.jiter.next_key();
+        if result.is_ok() {
+            return Ok(Self::shutup_borrow_checker(result.unwrap()));
+        }
+        self.jiter.next_key()
     }
 
     #[allow(clippy::missing_errors_doc)]

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -294,7 +294,7 @@ impl<'rj> RJiter<'rj> {
         //
         // Copy remaining bytes to the beginning of the buffer
         //
-        self.buffer.shift_buffer(pos, is_partial_string);
+        self.buffer.shift_buffer(0, pos);
 
         //
         // Read new bytes

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -146,7 +146,13 @@ impl<'rj> RJiter<'rj> {
         self.jiter.next_int()
     }
 
-    #[allow(clippy::missing_errors_doc)]
+    /// See `Jiter::next_key`
+    ///
+    /// The chunk from the key name to colon (:) should fit to the buffer.
+    ///
+    /// # Errors
+    ///
+    /// See `Jiter::next_key`
     pub fn next_key(&mut self) -> JiterResult<Option<&str>> {
         let result = self.jiter.next_key();
         if result.is_ok() {

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -2,22 +2,21 @@ use std::io::Read;
 use std::io::Write;
 
 use jiter::{Jiter, JiterResult, JsonValue, NumberAny, NumberInt};
+use crate::buffer::Buffer;
 
 pub type Peek = jiter::Peek;
 
 pub struct RJiter<'rj> {
     jiter: Jiter<'rj>,
     pos_before_call_jiter: usize,
-    reader: &'rj mut dyn Read,
-    buffer: &'rj mut [u8],
-    bytes_in_buffer: usize,
+    buffer: Buffer<'rj>,
 }
 
 impl<'rj> std::fmt::Debug for RJiter<'rj> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f,
-            "RJiter {{ jiter: {:?}, pos_before_call_jiter: {:?}, buffer: {:?}, bytes_in_buffer: {:?} }}",
-            self.jiter, self.pos_before_call_jiter, self.buffer, self.bytes_in_buffer)
+            "RJiter {{ jiter: {:?}, pos_before_call_jiter: {:?}, buffer: {:?} }}",
+            self.jiter, self.pos_before_call_jiter, self.buffer)
     }
 }
 
@@ -36,9 +35,7 @@ impl<'rj> RJiter<'rj> {
         RJiter {
             jiter: Jiter::new(jiter_buffer).with_allow_partial_strings(),
             pos_before_call_jiter: 0,
-            reader,
-            buffer: rjiter_buffer,
-            bytes_in_buffer,
+            buffer: Buffer::new(reader, rjiter_buffer),
         }
     }
 
@@ -243,7 +240,7 @@ impl<'rj> RJiter<'rj> {
             };
             if let Ok(bytes) = result {
                 writer.write_all(bytes).unwrap();
-                if self.jiter.current_index() <= self.bytes_in_buffer {
+                if self.jiter.current_index() <= self.buffer.bytes_in_buffer {
                     return Ok(());
                 }
                 self.on_before_call_jiter();
@@ -286,8 +283,8 @@ impl<'rj> RJiter<'rj> {
         //
         // Skip whitespaces
         //
-        if !is_partial_string && pos < self.bytes_in_buffer {
-            let mut skip_ws_parser = Jiter::new(&self.buffer[pos..self.bytes_in_buffer]);
+        if !is_partial_string && pos < self.buffer.bytes_in_buffer {
+            let mut skip_ws_parser = Jiter::new(&self.buffer.buffer[pos..self.buffer.bytes_in_buffer]);
             let _ = skip_ws_parser.finish();
             pos += skip_ws_parser.current_index();
         }
@@ -295,39 +292,23 @@ impl<'rj> RJiter<'rj> {
         //
         // Copy remaining bytes to the beginning of the buffer
         //
-        if pos > 0 {
-            if pos < self.bytes_in_buffer {
-                assert!(
-                    !is_partial_string,
-                    "Buffer should be completely consumed in partial string case"
-                );
-                self.buffer.copy_within(pos..self.bytes_in_buffer, 0);
-                self.bytes_in_buffer -= pos;
-            } else {
-                self.bytes_in_buffer = 0;
-            }
-        }
+        self.buffer.shift_buffer(pos, is_partial_string);
 
         //
         // Read new bytes
         //
-        let start_index = if is_partial_string {
-            1
-        } else {
-            self.bytes_in_buffer
-        };
-        let n_new_bytes = self.reader.read(&mut self.buffer[start_index..]).unwrap();
-        self.bytes_in_buffer += n_new_bytes;
+        let start_index = if is_partial_string { 1 } else { self.buffer.bytes_in_buffer };
+        let n_new_bytes = self.buffer.read_more(start_index);
 
         if is_partial_string {
-            self.buffer[0] = 34;
-            self.bytes_in_buffer += 1;
+            self.buffer.buffer[0] = 34; // Quote character
+            self.buffer.bytes_in_buffer += 1;
         }
 
         //
         // Create new Jiter and inform caller if any new bytes were read
         //
-        let jiter_buffer_2 = &self.buffer[..self.bytes_in_buffer];
+        let jiter_buffer_2 = &self.buffer.buffer[..self.buffer.bytes_in_buffer];
         let jiter_buffer = unsafe { std::mem::transmute::<&[u8], &'rj [u8]>(jiter_buffer_2) };
         self.jiter = Jiter::new(jiter_buffer).with_allow_partial_strings();
 
@@ -335,7 +316,7 @@ impl<'rj> RJiter<'rj> {
     }
 
     fn maybe_feed(&mut self) {
-        if self.jiter.current_index() > self.bytes_in_buffer / 2 {
+        if self.jiter.current_index() > self.buffer.bytes_in_buffer / 2 {
             self.feed();
         }
     }
@@ -343,7 +324,7 @@ impl<'rj> RJiter<'rj> {
     pub fn skip_token(&mut self, token: &[u8]) -> bool {
         self.maybe_feed();
 
-        let buf_view = &mut self.buffer[self.jiter.current_index()..self.bytes_in_buffer];
+        let buf_view = &mut self.buffer.buffer[self.jiter.current_index()..self.buffer.bytes_in_buffer];
         if !buf_view.starts_with(token) {
             return false;
         }

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -276,13 +276,16 @@ impl<'rj> RJiter<'rj> {
     }
 
     fn skip_spaces_feeding(&mut self, transparent_token: u8) -> bool {
-        let pos = self.jiter.current_index();
+        let to_pos = 0;
         let n_shifted_before = self.buffer.n_shifted_out;
 
-        self.buffer.skip_spaces(pos);
-        if pos < self.buffer.n_bytes && self.buffer.buf[pos] == transparent_token {
-            self.buffer.skip_spaces(pos + 1);
+        println!("skip_spaces_feeding, buf before skip spaces: {:?}, pos: {:?}", self.buffer, to_pos); // FIXME
+        self.buffer.skip_spaces(to_pos);
+        if to_pos < self.buffer.n_bytes && self.buffer.buf[to_pos] == transparent_token {
+            println!("skip_spaces_feeding, buf before skip spaces 2: {:?}, pos: {:?}", self.buffer, to_pos); // FIXME
+            self.buffer.skip_spaces(to_pos + 1);
         }
+        println!("skip_spaces_feeding, buf after skip spaces 2: {:?}, pos: {:?}", self.buffer, to_pos); // FIXME
 
         let is_shifted = self.buffer.n_shifted_out > n_shifted_before;
         if is_shifted {

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -2,7 +2,10 @@ use std::io::Read;
 use std::io::Write;
 
 use crate::buffer::Buffer;
-use jiter::{Jiter, JiterError, JiterErrorType, JiterResult, JsonError, JsonErrorType, JsonValue, NumberAny, NumberInt};
+use jiter::{
+    Jiter, JiterError, JiterErrorType, JiterResult, JsonError, JsonErrorType, JsonValue, NumberAny,
+    NumberInt,
+};
 
 pub type Peek = jiter::Peek;
 
@@ -166,9 +169,14 @@ impl<'rj> RJiter<'rj> {
             }
             let error = result.unwrap_err();
             if let JiterError {
-                error_type: JiterErrorType::JsonError(ref error_type @ (JsonErrorType::EofWhileParsingString | JsonErrorType::ExpectedObjectCommaOrEnd)),
+                error_type:
+                    JiterErrorType::JsonError(
+                        ref error_type @ (JsonErrorType::EofWhileParsingString
+                        | JsonErrorType::ExpectedObjectCommaOrEnd),
+                    ),
                 ..
-            } = error {
+            } = error
+            {
                 println!("next_key, before feed"); // FIXME
                 if self.buffer.read_more() > 0 {
                     println!("next_key, after feed (true)"); // FIXME

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use crate::buffer::Buffer;
 use jiter::{
-    Jiter, JiterError, JiterErrorType, JiterResult, JsonError, JsonErrorType, JsonValue, NumberAny,
+    Jiter, JiterError, JiterErrorType, JiterResult, JsonErrorType, JsonValue, NumberAny,
     NumberInt,
 };
 
@@ -158,7 +158,6 @@ impl<'rj> RJiter<'rj> {
         }
         self.skip_spaces_feeding(b',');
         loop {
-            println!("next_key, buf: {:?}", self.buffer); // FIXME
             let result = self.jiter.next_key();
             if result.is_ok() {
                 return unsafe {
@@ -171,21 +170,17 @@ impl<'rj> RJiter<'rj> {
             if let JiterError {
                 error_type:
                     JiterErrorType::JsonError(
-                        ref error_type @ (JsonErrorType::EofWhileParsingString
+                        ref _error_type @ (JsonErrorType::EofWhileParsingString
                         | JsonErrorType::ExpectedObjectCommaOrEnd
-                        | JsonErrorType::EofWhileParsingObject)
-                        ,
+                        | JsonErrorType::EofWhileParsingObject),
                     ),
                 ..
             } = error
             {
-                println!("next_key, before feed"); // FIXME
                 if self.buffer.read_more() > 0 {
-                    println!("next_key, after feed (true)"); // FIXME
                     self.create_new_jiter();
                     continue;
                 }
-                println!("next_key, after feed (false)"); // FIXME
             }
             return Err(error);
         }

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -21,12 +21,6 @@ impl<'rj> std::fmt::Debug for RJiter<'rj> {
     }
 }
 
- fn make_new_jiter<'rj>(buffer: &'rj mut [u8], bytes_in_buffer: usize) -> Jiter<'rj> {
-     let jiter_buffer_2 = &buffer[..bytes_in_buffer];
-     let jiter_buffer = unsafe { std::mem::transmute::<&[u8], &'rj [u8]>(jiter_buffer_2) };
-     Jiter::new(jiter_buffer).with_allow_partial_strings()
- }
-
 impl<'rj> RJiter<'rj> {
     #[allow(clippy::missing_errors_doc)]
     #[allow(clippy::missing_panics_doc)]
@@ -150,22 +144,14 @@ impl<'rj> RJiter<'rj> {
         self.jiter.next_int()
     }
 
-    fn shutup_borrow_checker(result: Option<&str>) -> Option<&'rj str> {
-        match result {
-            Some(key) => {
-                let key_2 = unsafe { std::mem::transmute::<&str, &'rj str>(key) };
-                Some(key_2)
-            }
-            None => None
-        }
-    }
-
     #[allow(clippy::missing_errors_doc)]
     pub fn next_key(&mut self) -> JiterResult<Option<&str>> {
         let result = self.jiter.next_key();
         if result.is_ok() {
             return unsafe {
-                std::mem::transmute::<JiterResult<Option<&str>>, JiterResult<Option<&'rj str>>>(result)
+                std::mem::transmute::<JiterResult<Option<&str>>, JiterResult<Option<&'rj str>>>(
+                    result,
+                )
             };
         }
         self.skip_spaces_feeding(b',');

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -25,19 +25,19 @@ impl<'rj> std::fmt::Debug for RJiter<'rj> {
 impl<'rj> RJiter<'rj> {
     #[allow(clippy::missing_errors_doc)]
     #[allow(clippy::missing_panics_doc)]
-    pub fn new(reader: &'rj mut dyn Read, buffer: &'rj mut [u8]) -> Self {
-        let bytes_in_buffer = reader.read(buffer).unwrap();
-        let jiter_buffer = &buffer[..bytes_in_buffer];
-        let rjiter_buffer = unsafe {
+    pub fn new(reader: &'rj mut dyn Read, buf: &'rj mut [u8]) -> Self {
+        let buf_alias = unsafe {
             #[allow(mutable_transmutes)]
             #[allow(clippy::transmute_ptr_to_ptr)]
-            std::mem::transmute::<&[u8], &'rj mut [u8]>(buffer)
+            std::mem::transmute::<&[u8], &'rj mut [u8]>(buf)
         };
+        let buffer = Buffer::new(reader, buf_alias);
+        let jiter = Jiter::new(&buf[..buffer.n_bytes]).with_allow_partial_strings();
 
         RJiter {
-            jiter: Jiter::new(jiter_buffer).with_allow_partial_strings(),
+            jiter,
             pos_before_call_jiter: 0,
-            buffer: Buffer::new(reader, rjiter_buffer),
+            buffer,
         }
     }
 

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -94,3 +94,17 @@ fn test_skip_spaces_eof_without_non_space_and_nonzero_pos() {
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"  ");
     assert_eq!(buffer.n_shifted_out, 3);
 }
+
+#[test]
+fn test_noop_on_no_shift() {
+    let input = "abc";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 4];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(0, 0);
+
+    assert_eq!(buffer.n_bytes, 3);
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");
+    assert_eq!(buffer.n_shifted_out, 0);
+}

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -1,0 +1,16 @@
+use std::io::Cursor;
+use rjiter::buffer::Buffer;
+
+#[test]
+fn test_basic_skip_spaces() {
+    let input = "    abc".as_bytes();
+    let mut reader = Cursor::new(input);
+    let mut buf = [0u8; 16];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    // act
+    buffer.skip_spaces(0);
+
+    // assert
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");
+}

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -56,3 +56,31 @@ fn test_skip_spaces_with_many_reads_and_nonzero_pos() {
     // assert
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"  a");
 }
+
+#[test]
+fn test_skip_spaces_eof_without_non_space() {
+    let input = "     ".as_bytes();
+    let mut reader = Cursor::new(input);
+    let mut buf = [0u8; 4];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    // act
+    buffer.skip_spaces(0);
+
+    // assert
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"");
+}
+
+#[test]
+fn test_skip_spaces_eof_without_non_space_and_nonzero_pos() {
+    let input = "     ".as_bytes();
+    let mut reader = Cursor::new(input);
+    let mut buf = [0u8; 4];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    // act
+    buffer.skip_spaces(2);
+
+    // assert
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"  ");
+}

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -28,3 +28,17 @@ fn test_skip_spaces_from_non_zero_pos() {
     // assert
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"  abc");
 }
+
+#[test]
+fn test_skip_spaces_with_one_read() {
+    let input = "     abc".as_bytes();
+    let mut reader = Cursor::new(input);
+    let mut buf = [0u8; 4];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    // act
+    buffer.skip_spaces(0);
+
+    // assert
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");
+}

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -163,3 +163,42 @@ fn test_noop_shift_at_end() {
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");
     assert_eq!(buffer.n_shifted_out, 0);
 }
+
+#[test]
+fn test_shift_pos1_to_pos0() {
+    let input = "abcd12345";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 10];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(0, 1);
+
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"bcd12345");
+    assert_eq!(buffer.n_shifted_out, 1);
+}
+
+#[test]
+fn test_shift_preend_to_pos0() {
+    let input = "abcd12345";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 10];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(0, input.len() - 1);
+
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"5");
+    assert_eq!(buffer.n_shifted_out, input.len() - 1);
+}
+
+#[test]
+fn test_shift_preend_to_pos1() {
+    let input = "abcd12345";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 10];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(1, input.len() - 1);
+
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"a5");
+    assert_eq!(buffer.n_shifted_out, input.len() - 2);
+}

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -96,7 +96,21 @@ fn test_skip_spaces_eof_without_non_space_and_nonzero_pos() {
 }
 
 #[test]
-fn test_noop_on_no_shift() {
+fn sanity_test_shift() {
+    let input = "abcd12345";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 10];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(3, 7);
+
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc345");
+    assert_eq!(buffer.n_shifted_out, 4);
+}
+
+
+#[test]
+fn test_noop_shift_at_pos0() {
     let input = "abc";
     let mut reader = Cursor::new(input.as_bytes());
     let mut buf = [0u8; 4];

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -14,3 +14,17 @@ fn test_basic_skip_spaces() {
     // assert
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");
 }
+
+#[test]
+fn test_skip_spaces_from_non_zero_pos() {
+    let input = "    abc".as_bytes();
+    let mut reader = Cursor::new(input);
+    let mut buf = [0u8; 16];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    // act
+    buffer.skip_spaces(2);
+
+    // assert
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"  abc");
+}

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -104,10 +104,9 @@ fn sanity_test_shift() {
 
     buffer.shift_buffer(3, 7);
 
-    assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc345");
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc45");
     assert_eq!(buffer.n_shifted_out, 4);
 }
-
 
 #[test]
 fn test_noop_shift_at_pos0() {
@@ -117,6 +116,48 @@ fn test_noop_shift_at_pos0() {
     let mut buffer = Buffer::new(&mut reader, &mut buf);
 
     buffer.shift_buffer(0, 0);
+
+    assert_eq!(buffer.n_bytes, 3);
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");
+    assert_eq!(buffer.n_shifted_out, 0);
+}
+
+#[test]
+fn test_noop_shift_at_pos1() {
+    let input = "abc";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 4];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(1, 1);
+
+    assert_eq!(buffer.n_bytes, 3);
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");
+    assert_eq!(buffer.n_shifted_out, 0);
+}
+
+#[test]
+fn test_noop_shift_at_end_minus1() {
+    let input = "abc";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 4];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(2, 2);
+
+    assert_eq!(buffer.n_bytes, 3);
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");
+    assert_eq!(buffer.n_shifted_out, 0);
+}
+
+#[test]
+fn test_noop_shift_at_end() {
+    let input = "abc";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 4];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(3, 3);
 
     assert_eq!(buffer.n_bytes, 3);
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -3,8 +3,9 @@ use std::io::Cursor;
 
 #[test]
 fn test_basic_skip_spaces() {
-    let input = "    abc".as_bytes();
-    let mut reader = Cursor::new(input);
+    let spaces = " ".repeat(4);
+    let input = format!("{spaces}abc");
+    let mut reader = Cursor::new(input.as_bytes());
     let mut buf = [0u8; 16];
     let mut buffer = Buffer::new(&mut reader, &mut buf);
 
@@ -13,12 +14,14 @@ fn test_basic_skip_spaces() {
 
     // assert
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");
+    assert_eq!(buffer.n_shifted_out, 4);
 }
 
 #[test]
 fn test_skip_spaces_from_non_zero_pos() {
-    let input = "    abc".as_bytes();
-    let mut reader = Cursor::new(input);
+    let spaces = " ".repeat(4);
+    let input = format!("{spaces}abc");
+    let mut reader = Cursor::new(input.as_bytes());
     let mut buf = [0u8; 16];
     let mut buffer = Buffer::new(&mut reader, &mut buf);
 
@@ -27,12 +30,14 @@ fn test_skip_spaces_from_non_zero_pos() {
 
     // assert
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"  abc");
+    assert_eq!(buffer.n_shifted_out, 2);
 }
 
 #[test]
 fn test_skip_spaces_with_one_read() {
-    let input = "     abc".as_bytes();
-    let mut reader = Cursor::new(input);
+    let spaces = " ".repeat(5);
+    let input = format!("{spaces}abc");
+    let mut reader = Cursor::new(input.as_bytes());
     let mut buf = [0u8; 4];
     let mut buffer = Buffer::new(&mut reader, &mut buf);
 
@@ -41,12 +46,14 @@ fn test_skip_spaces_with_one_read() {
 
     // assert
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");
+    assert_eq!(buffer.n_shifted_out, 5);
 }
 
 #[test]
 fn test_skip_spaces_with_many_reads_and_nonzero_pos() {
-    let input = "                             abc".as_bytes();
-    let mut reader = Cursor::new(input);
+    let spaces = " ".repeat(19);
+    let input = format!("{spaces}abc");
+    let mut reader = Cursor::new(input.as_bytes());
     let mut buf = [0u8; 4];
     let mut buffer = Buffer::new(&mut reader, &mut buf);
 
@@ -55,12 +62,13 @@ fn test_skip_spaces_with_many_reads_and_nonzero_pos() {
 
     // assert
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"  a");
+    assert_eq!(buffer.n_shifted_out, 17);
 }
 
 #[test]
 fn test_skip_spaces_eof_without_non_space() {
-    let input = "     ".as_bytes();
-    let mut reader = Cursor::new(input);
+    let input = " ".repeat(5);
+    let mut reader = Cursor::new(input.as_bytes());
     let mut buf = [0u8; 4];
     let mut buffer = Buffer::new(&mut reader, &mut buf);
 
@@ -69,12 +77,13 @@ fn test_skip_spaces_eof_without_non_space() {
 
     // assert
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"");
+    assert_eq!(buffer.n_shifted_out, 5);
 }
 
 #[test]
 fn test_skip_spaces_eof_without_non_space_and_nonzero_pos() {
-    let input = "     ".as_bytes();
-    let mut reader = Cursor::new(input);
+    let input = " ".repeat(5);
+    let mut reader = Cursor::new(input.as_bytes());
     let mut buf = [0u8; 4];
     let mut buffer = Buffer::new(&mut reader, &mut buf);
 
@@ -83,4 +92,5 @@ fn test_skip_spaces_eof_without_non_space_and_nonzero_pos() {
 
     // assert
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"  ");
+    assert_eq!(buffer.n_shifted_out, 3);
 }

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -1,5 +1,5 @@
-use std::io::Cursor;
 use rjiter::buffer::Buffer;
+use std::io::Cursor;
 
 #[test]
 fn test_basic_skip_spaces() {

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -42,3 +42,17 @@ fn test_skip_spaces_with_one_read() {
     // assert
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"abc");
 }
+
+#[test]
+fn test_skip_spaces_with_many_reads_and_nonzero_pos() {
+    let input = "                             abc".as_bytes();
+    let mut reader = Cursor::new(input);
+    let mut buf = [0u8; 4];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    // act
+    buffer.skip_spaces(2);
+
+    // assert
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"  ab");
+}

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -54,5 +54,5 @@ fn test_skip_spaces_with_many_reads_and_nonzero_pos() {
     buffer.skip_spaces(2);
 
     // assert
-    assert_eq!(&buffer.buf[..buffer.n_bytes], b"  ab");
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"  a");
 }

--- a/rjiter/tests/buffer_test.rs
+++ b/rjiter/tests/buffer_test.rs
@@ -202,3 +202,55 @@ fn test_shift_preend_to_pos1() {
     assert_eq!(&buffer.buf[..buffer.n_bytes], b"a5");
     assert_eq!(buffer.n_shifted_out, input.len() - 2);
 }
+
+#[test]
+fn test_shift_end_to_pos0() {
+    let input = "abcd12345";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 10];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(0, input.len());
+
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"");
+    assert_eq!(buffer.n_shifted_out, input.len());
+}
+
+#[test]
+fn test_shift_end_to_pos1() {
+    let input = "abcd12345";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 10];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(1, input.len());
+
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"a");
+    assert_eq!(buffer.n_shifted_out, input.len() - 1);
+}
+
+#[test]
+fn test_shift_postend_to_pos0() {
+    let input = "abcd12345";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 10];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(0, input.len() + 1);
+
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"");
+    assert_eq!(buffer.n_shifted_out, input.len());
+}
+
+#[test]
+fn test_shift_postend_to_pos1() {
+    let input = "abcd12345";
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut buf = [0u8; 10];
+    let mut buffer = Buffer::new(&mut reader, &mut buf);
+
+    buffer.shift_buffer(1, input.len() + 1);
+
+    assert_eq!(&buffer.buf[..buffer.n_bytes], b"a");
+    assert_eq!(buffer.n_shifted_out, input.len() - 1);
+}

--- a/rjiter/tests/one_byte_reader.rs
+++ b/rjiter/tests/one_byte_reader.rs
@@ -1,6 +1,6 @@
 use std::io::Read;
 
-struct OneByteReader<I>
+pub struct OneByteReader<I>
 where
     I: Iterator<Item = u8>,
 {
@@ -11,7 +11,7 @@ impl<I> OneByteReader<I>
 where
     I: Iterator<Item = u8>,
 {
-    fn new(iter: I) -> Self {
+    pub fn new(iter: I) -> Self {
         OneByteReader { iter }
     }
 }

--- a/rjiter/tests/one_byte_reader.rs
+++ b/rjiter/tests/one_byte_reader.rs
@@ -1,0 +1,31 @@
+use std::io::Read;
+
+struct OneByteReader<I>
+where
+    I: Iterator<Item = u8>,
+{
+    iter: I,
+}
+
+impl<I> OneByteReader<I>
+where
+    I: Iterator<Item = u8>,
+{
+    fn new(iter: I) -> Self {
+        OneByteReader { iter }
+    }
+}
+
+impl<I> Read for OneByteReader<I>
+where
+    I: Iterator<Item = u8>,
+{
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if let Some(next_byte) = self.iter.next() {
+            buf[0] = next_byte;
+            Ok(1)
+        } else {
+            Ok(0)
+        }
+    }
+}

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -144,15 +144,17 @@ fn skip_token() {
 }
 
 #[test]
-fn next_key() {
-    let input = r#","foo": "bar""#;
-    let mut buffer = [0u8; 16];
+fn multi_read_next_key() {
+    let lot_of_spaces = " ".repeat(32);
+    let input = format!(r#"{lot_of_spaces},{lot_of_spaces}foo": "bar""#);
+    let mut buffer = [0u8; 10];
     let mut reader = Cursor::new(input.as_bytes());
 
     let mut rjiter = RJiter::new(&mut reader, &mut buffer);
 
     // act
     let result = rjiter.next_key();
+    println!("multi_read_next_key result: {:?}", result);
 
     // assert
     assert!(result.is_ok());

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -144,7 +144,7 @@ fn skip_token() {
 }
 
 #[test]
-fn multi_read_next_key() {
+fn skip_spaces_for_next_key() {
     let lot_of_spaces = " ".repeat(32);
     let input = format!(r#"{lot_of_spaces},{lot_of_spaces}foo": "bar""#);
     let mut buffer = [0u8; 10];

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -157,7 +157,7 @@ fn skip_spaces_for_next_key() {
 
     // act
     let result = rjiter.next_key();
-    println!("multi_read_next_key result: {:?}", result);
+    println!("skip_spaces_for_next_key result: {:?}", result);
 
     // assert
     assert!(result.is_ok());
@@ -178,13 +178,15 @@ fn next_key_from_one_byte_reader() {
 
     // act
     let result = rjiter.next_key();
+    println!("next_key_from_one_byte_reader result: {:?}", result);
 
     // assert
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), Some("foo"));
 
+    // FIXME: uncommend when ready
     // bonus assert: key value
-    let result = rjiter.next_str();
-    assert!(result.is_ok());
-    assert_eq!(result.unwrap(), "bar");
+    // let result = rjiter.next_str();
+    // assert!(result.is_ok());
+    // assert_eq!(result.unwrap(), "bar");
 }

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -146,7 +146,7 @@ fn skip_token() {
 #[test]
 fn skip_spaces_for_next_key() {
     let lot_of_spaces = " ".repeat(32);
-    let input = format!(r#"{lot_of_spaces},{lot_of_spaces}foo": "bar""#);
+    let input = format!(r#"{lot_of_spaces},{lot_of_spaces}"foo": "bar""#);
     let mut buffer = [0u8; 10];
     let mut reader = Cursor::new(input.as_bytes());
 

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -6,6 +6,9 @@ use jiter::LazyIndexMap;
 use jiter::Peek;
 use rjiter::RJiter;
 
+mod one_byte_reader;
+use crate::one_byte_reader::OneByteReader;
+
 #[test]
 fn sanity_check() {
     let input = r#"{}}"#;

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -18,6 +18,7 @@ fn sanity_check() {
     let mut rjiter = RJiter::new(&mut reader, &mut buffer);
 
     let result = rjiter.next_value();
+    println!("sanity_check result: {:?}", result);
     assert!(result.is_ok());
 
     let empty_object = JsonValue::Object(Arc::new(LazyIndexMap::new()));

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -165,3 +165,23 @@ fn skip_spaces_for_next_key() {
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), "bar");
 }
+
+#[test]
+fn next_key_from_one_byte_reader() {
+    let input = r#" , "foo": "bar"}"#.bytes();
+    let mut reader = OneByteReader::new(input);
+    let mut buffer = [0u8; 10];
+    let mut rjiter = RJiter::new(&mut reader, &mut buffer);
+
+    // act
+    let result = rjiter.next_key();
+
+    // assert
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), Some("foo"));
+
+    // bonus assert: key value
+    let result = rjiter.next_str();
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "bar");
+}

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -142,3 +142,24 @@ fn skip_token() {
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), jiter::NumberInt::Int(42));
 }
+
+#[test]
+fn next_key() {
+    let input = r#","foo": "bar""#;
+    let mut buffer = [0u8; 16];
+    let mut reader = Cursor::new(input.as_bytes());
+
+    let mut rjiter = RJiter::new(&mut reader, &mut buffer);
+
+    // act
+    let result = rjiter.next_key();
+
+    // assert
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), Some("foo"));
+
+    // bonus assert: key value
+    let result = rjiter.next_str();
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "bar");
+}


### PR DESCRIPTION
- For `next_key`, skip spaces and loop till completion
- Extract buffer operations to "Buffer" object
- Buffer ops: read_more, shift_buffer, skip_spaces
- Create a one-byte reader for testing multiple reads
- Convince borrow checker that code is correct

Part of #10 