### PR TITLE
Regression write_long_str

### DIFF
--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -1,6 +1,6 @@
+use std::cmp::min;
 use std::io::Read;
 use std::io::Write;
-use std::cmp::min;
 
 use crate::buffer::Buffer;
 use crate::buffer::ChangeFlag;

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -149,6 +149,36 @@ fn pass_through_long_bytes() {
 }
 
 #[test]
+fn pass_through_long_string() {
+    let input = r#""very very very long string""#;
+    let mut buffer = [0u8; 5];
+    let mut reader = OneByteReader::new(input.bytes());
+    let mut writer = Vec::new();
+
+    let mut rjiter = RJiter::new(&mut reader, &mut buffer);
+
+    let wb = rjiter.write_long_str(&mut writer);
+    wb.unwrap();
+
+    assert_eq!(writer, "very very very long string".as_bytes());
+}
+
+#[test]
+fn regression_pass_through_long_string_with_chunk_reader() {
+    let input = r#""very very very long string""#;
+    let mut buffer = [0u8; 5];
+    let mut reader = Cursor::new(input.as_bytes());
+    let mut writer = Vec::new();
+
+    let mut rjiter = RJiter::new(&mut reader, &mut buffer);
+
+    let wb = rjiter.write_long_str(&mut writer);
+    wb.unwrap();
+
+    assert_eq!(writer, "very very very long string".as_bytes());
+}
+
+#[test]
 fn escapes_in_pass_through_long_bytes() {
     let input = r#""escapes X\n\\\"\u0410""#;
     let pos = input.find("X").unwrap();


### PR DESCRIPTION
Writing a long string is a bit different than writing a long bytes. Fix buffer manipulations:

- do not change a char outside the buffer
- restore the char back
