### PR TITLE
Regression for `finish()`, handle end-of-the-buffer

### DIFF
--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -415,8 +415,10 @@ impl<'rj> RJiter<'rj> {
     pub fn finish(&mut self) -> RJiterResult<()> {
         loop {
             self.jiter.finish()?;
-            if self.buffer.read_more()? == 0 {
-                return Ok(());
+            if self.jiter.current_index() < self.buffer.buf.len() {
+                if self.buffer.read_more()? == 0 {
+                    return Ok(());
+                }
             }
             self.buffer.shift_buffer(0, self.jiter.current_index());
             self.create_new_jiter();

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -424,6 +424,12 @@ impl<'rj> RJiter<'rj> {
     }
 
     //  ------------------------------------------------------------
+
+    pub fn current_index(&self) -> usize {
+        self.jiter.current_index() + self.buffer.n_shifted_out
+    }
+
+    //  ------------------------------------------------------------
     // Pass-through long strings and bytes
     //
 

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -415,6 +415,7 @@ impl<'rj> RJiter<'rj> {
     pub fn finish(&mut self) -> RJiterResult<()> {
         loop {
             self.jiter.finish()?;
+            #[allow(clippy::collapsible_if)]
             if self.jiter.current_index() < self.buffer.buf.len() {
                 if self.buffer.read_more()? == 0 {
                     return Ok(());
@@ -427,6 +428,7 @@ impl<'rj> RJiter<'rj> {
 
     //  ------------------------------------------------------------
 
+    #[must_use]
     pub fn current_index(&self) -> usize {
         self.jiter.current_index() + self.buffer.n_shifted_out
     }

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -364,6 +364,26 @@ fn finish_no_when_need_feed() {
     assert!(result.is_err());
 }
 
+#[test]
+fn handle_buffer_end_pos_in_finish() {
+    let input = r#"true  }  false"#;
+    let pos = input.find("}").unwrap();
+    let mut buffer = vec![0u8; pos + 1];
+    let mut reader = Cursor::new(input);
+    let mut rjiter = RJiter::new(&mut reader, &mut buffer);
+
+    // Move the jiter position to the end of buffer
+    let result = rjiter.next_bool();
+    assert_eq!(result.unwrap(), true);
+    let result = rjiter.next_key();
+    assert_eq!(result.unwrap(), None);
+    assert_eq!(rjiter.current_index(), pos + 1);
+
+    // Act and assert: not finished
+    let result = rjiter.finish();
+    assert!(result.is_err());
+}
+
 //
 // Skip token
 //


### PR DESCRIPTION
At the end of the buffer, `read_more()` returns zero, which was wrongly interpreted as "end of the input", and processing stopped premature.