### PR TITLE
Rj51 unicode code point on the buffer border

### DIFF
--- a/rjiter/Cargo.toml
+++ b/rjiter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rjiter"
-version = "1.1.2"
+version = "1.1.3"
 edition = "2021"
 authors = ["Oleg Parashchenko <olpa@uucode.com>"]
 description = "Streaming JSON parser on top of Jiter"

--- a/rjiter/changelog.md
+++ b/rjiter/changelog.md
@@ -1,3 +1,8 @@
+## [1.1.3] - 2025-03-11
+
+- Fix `InvalidUnicodeCodePoint` when the buffer border breaks a multibyte character
+
+
 ## [1.1.2] - 2025-02-11
 
 - Add missing `std::error::Error` trait implementation

--- a/rjiter/src/rjiter.rs
+++ b/rjiter/src/rjiter.rs
@@ -571,6 +571,15 @@ impl<'rj> RJiter<'rj> {
                 }
             };
 
+            // Correct the segment end position to not break a unicode code point
+            let segment_end_pos = (0..=segment_end_pos)
+                .rev()
+                .find(
+                    #[allow(clippy::indexing_slicing)]
+                    |&pos| self.buffer.buf[pos] < 128,
+                )
+                .unwrap_or(0);
+
             // Write the segment
             if segment_end_pos > 1 {
                 write_segment(

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -176,6 +176,38 @@ fn regression_pass_through_long_string_with_chunk_reader() {
 }
 
 #[test]
+fn write_long_with_unicode_code_point_on_border() {
+    let input = r#""Grüße""#;
+    for buf_len in 3..9 {
+        // Test write_long_bytes
+        {
+            let mut buffer = vec![0u8; buf_len];
+            let mut reader = OneByteReader::new(input.bytes());
+            let mut writer = Vec::new();
+            let mut rjiter = RJiter::new(&mut reader, &mut buffer);
+
+            let wb = rjiter.write_long_bytes(&mut writer);
+            wb.unwrap();
+
+            assert_eq!(writer, "Grüße".as_bytes());
+        }
+
+        // Test write_long_str
+        {
+            let mut buffer = vec![0u8; buf_len];
+            let mut reader = OneByteReader::new(input.bytes());
+            let mut writer = Vec::new();
+            let mut rjiter = RJiter::new(&mut reader, &mut buffer);
+
+            let wb = rjiter.write_long_str(&mut writer);
+            wb.unwrap();
+
+            assert_eq!(writer, "Grüße".as_bytes());
+        }
+    }
+}
+
+#[test]
 fn escapes_in_pass_through_long_bytes() {
     let input = r#""escapes X\n\\\"\u0410""#;
     let pos = input.find("X").unwrap();

--- a/rjiter/tests/rjiter_test.rs
+++ b/rjiter/tests/rjiter_test.rs
@@ -177,8 +177,8 @@ fn regression_pass_through_long_string_with_chunk_reader() {
 
 #[test]
 fn write_long_with_unicode_code_point_on_border() {
-    let input = r#""Grüße""#;
-    for buf_len in 3..9 {
+    let input = r#""Viele Grüße""#;
+    for buf_len in input.len()..input.len() + 10 {
         // Test write_long_bytes
         {
             let mut buffer = vec![0u8; buf_len];
@@ -189,7 +189,7 @@ fn write_long_with_unicode_code_point_on_border() {
             let wb = rjiter.write_long_bytes(&mut writer);
             wb.unwrap();
 
-            assert_eq!(writer, "Grüße".as_bytes());
+            assert_eq!(writer, "Viele Grüße".as_bytes());
         }
 
         // Test write_long_str
@@ -202,7 +202,7 @@ fn write_long_with_unicode_code_point_on_border() {
             let wb = rjiter.write_long_str(&mut writer);
             wb.unwrap();
 
-            assert_eq!(writer, "Grüße".as_bytes());
+            assert_eq!(writer, "Viele Grüße".as_bytes());
         }
     }
 }

--- a/scan_json/Cargo.toml
+++ b/scan_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scan_json"
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 authors = ["Oleg Parashchenko <olpa@uucode.com>"]
 description = "React to elements in a JSON stream"
@@ -14,4 +14,4 @@ categories = ["parser-implementations", "parsing"]
 crate-type = ["lib"]
 
 [dependencies]
-rjiter = "1.1.2"
+rjiter = "1.1.3"

--- a/scan_json/changelog.md
+++ b/scan_json/changelog.md
@@ -1,0 +1,8 @@
+## [1.0.1] - 2025-02-11
+
+- Update the dependency on `rjiter`
+
+
+## [1.0.0] - 2025-02-11
+
+- First public release


### PR DESCRIPTION
- Add a test, fix the issue
- Bump versions of `rjiter` and `scan_json`

close #51 