### PR TITLE
Sj65 identity transformation

### DIFF
--- a/scan_json/README.md
+++ b/scan_json/README.md
@@ -52,8 +52,15 @@ fn on_content(rjiter_cell: &RefCell<RJiter>, writer_cell: &RefCell<dyn Write>) -
 }
 ```
 
+## Complete example: Identity transformation
 
-## Complete example
+The identity transformation copies JSON input to output, retaining the original structure.
+
+The function [`crate::idtransform::idtransform()`] is not just a library function,
+but also an example of advanced `scan` use. Read the source code for details.
+
+
+## Complete example: LLM output
 
 Summary:
 

--- a/scan_json/changelog.md
+++ b/scan_json/changelog.md
@@ -2,6 +2,7 @@
 
 - Allow triggering on arrays
 - Allow triggering on basic values (strings, numbers, booleans, null)
+- Trigger on all objects, not only on unnamed in array context
 
 
 ## [1.0.2] - 2025-05-03

--- a/scan_json/changelog.md
+++ b/scan_json/changelog.md
@@ -3,6 +3,7 @@
 - Allow triggering on arrays
 - Allow triggering on basic values (strings, numbers, booleans, null)
 - Trigger on all objects, not only on unnamed in array context
+- Add `IOError` to `ScanError`
 
 
 ## [1.0.2] - 2025-05-03

--- a/scan_json/changelog.md
+++ b/scan_json/changelog.md
@@ -4,6 +4,7 @@
 - Allow triggering on basic values (strings, numbers, booleans, null)
 - Trigger on all objects, not only on unnamed in array context
 - Add `IOError` to `ScanError`
+- Add `idtransform` and `copy_atom`
 
 
 ## [1.0.2] - 2025-05-03

--- a/scan_json/src/action.rs
+++ b/scan_json/src/action.rs
@@ -15,6 +15,12 @@ pub enum StreamOp {
     Error(Box<dyn std::error::Error>),
 }
 
+impl<E: std::error::Error + 'static> From<E> for StreamOp {
+    fn from(error: E) -> Self {
+        StreamOp::Error(Box::new(error))
+    }
+}
+
 pub type BoxedMatcher<'a> = Box<dyn Matcher + 'a>;
 
 /// Type alias for a boxed action function

--- a/scan_json/src/error.rs
+++ b/scan_json/src/error.rs
@@ -16,6 +16,7 @@ pub enum Error {
     InternalError(usize, String),
     MaxNestingExceeded(usize, usize),
     ActionError(Box<dyn std::error::Error>, usize),
+    IOError(std::io::Error), // for writing in id-transform; reading errors are inside RJiterError
 }
 
 impl std::error::Error for Error {}
@@ -32,6 +33,7 @@ impl std::fmt::Display for Error {
                 f,
                 "Max nesting exceeded at position {pos} with level {level}"
             ),
+            Error::IOError(e) => write!(f, "IO error: {e}"),
         }
     }
 }
@@ -39,6 +41,12 @@ impl std::fmt::Display for Error {
 impl From<rjiter::Error> for Error {
     fn from(error: rjiter::Error) -> Self {
         Error::RJiterError(error)
+    }
+}
+
+impl From<std::io::Error> for Error {
+    fn from(error: std::io::Error) -> Self {
+        Error::IOError(error)
     }
 }
 

--- a/scan_json/src/idtransform.rs
+++ b/scan_json/src/idtransform.rs
@@ -131,7 +131,7 @@ impl<'a> Matcher for IdtMatcher<'a> {
             return false;
         }
         let mut matcher_to_handler = self.matcher_to_handler.borrow_mut();
-        matcher_to_handler.is_top_level = context.is_empty();
+        matcher_to_handler.is_top_level = context.len() < 2;
         true
     }
 }

--- a/scan_json/src/idtransform.rs
+++ b/scan_json/src/idtransform.rs
@@ -1,0 +1,7 @@
+use crate::RJiter;
+use std::io::Write;
+
+pub fn idtransform(_rjiter: &mut RJiter, _writer: &mut dyn Write) {
+    #[warn(clippy::needless_return)]
+    return;
+}

--- a/scan_json/src/idtransform.rs
+++ b/scan_json/src/idtransform.rs
@@ -80,7 +80,6 @@ impl<'a> IdTransform<'a> {
     }
 
     fn write_seqpos(&mut self) -> Result<(), Box<dyn std::error::Error>> {
-        println!("write_seqpos: seqpos: {:?}", self.seqpos); // FIXME
         match &self.seqpos {
             IdtSequencePos::AtBeginning => {
                 self.seqpos = IdtSequencePos::InMiddle;
@@ -160,7 +159,6 @@ impl<'a> IdtMatcherForKey<'a> {
 impl<'a> Matcher for IdtMatcherForKey<'a> {
     fn matches(&self, name: &str, _context: &[ContextFrame]) -> bool {
         let mut idt = self.idt.borrow_mut();
-        println!("matches: name: {:?}, seqpos: {:?}", name, idt.seqpos); // FIXME
         idt.seqpos = match &idt.seqpos {
             IdtSequencePos::AtBeginning => IdtSequencePos::AtBeginningKey(name.to_string()),
             _ => IdtSequencePos::InMiddleKey(name.to_string()),
@@ -188,12 +186,6 @@ fn on_atom(rjiter_cell: &RefCell<RJiter>, idt_cell: &RefCell<IdTransform>) -> St
         return StreamOp::Error(e);
     }
 
-    println!(
-        "!!! on_atom: seqpos: {:?}, peeked: {:?}",
-        idt.seqpos,
-        rjiter.peek()
-    ); // FIXME
-
     match rjiter.peek() {
         Ok(peeked) => match copy_atom(peeked, &mut rjiter, idt.get_writer_mut()) {
             Ok(()) => StreamOp::ValueIsConsumed,
@@ -205,8 +197,6 @@ fn on_atom(rjiter_cell: &RefCell<RJiter>, idt_cell: &RefCell<IdTransform>) -> St
 
 fn on_struct(bytes: &[u8], idt_cell: &RefCell<IdTransform>) -> StreamOp {
     let mut idt = idt_cell.borrow_mut();
-
-    println!("!!! on_struct: seqpos: {:?}", idt.seqpos); // FIXME
 
     if let Err(e) = idt.write_seqpos() {
         return StreamOp::Error(e);

--- a/scan_json/src/idtransform.rs
+++ b/scan_json/src/idtransform.rs
@@ -1,5 +1,42 @@
-use crate::RJiter;
+use crate::{rjiter::jiter::Peek, Error as ScanError, RJiter, Result as ScanResult};
 use std::io::Write;
+
+/// Copy a JSON atom (string, number, boolean, or null) from the input to the output.
+/// Advances the input iterator to the next token.
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// * The input JSON is malformed
+/// * An IO error occurs while writing to the output
+/// * An unexpected token type is encountered
+pub fn copy_atom(peeked: Peek, rjiter: &mut RJiter, writer: &mut dyn Write) -> ScanResult<()> {
+    if peeked == Peek::String {
+        rjiter.write_long_bytes(writer)?;
+        return Ok(());
+    }
+    if peeked == Peek::Null {
+        rjiter.known_null()?;
+        writer.write_all(b"null")?;
+        return Ok(());
+    }
+    if peeked == Peek::True {
+        rjiter.known_bool(peeked)?;
+        writer.write_all(b"true")?;
+        return Ok(());
+    }
+    if peeked == Peek::False {
+        rjiter.known_bool(peeked)?;
+        writer.write_all(b"false")?;
+        return Ok(());
+    }
+    let maybe_number = rjiter.next_number_bytes();
+    if let Ok(number) = maybe_number {
+        writer.write_all(number)?;
+        return Ok(());
+    };
+    Err(ScanError::UnhandledPeek(peeked, rjiter.current_index()))
+}
 
 pub fn idtransform(_rjiter: &mut RJiter, _writer: &mut dyn Write) {
     #[warn(clippy::needless_return)]

--- a/scan_json/src/lib.rs
+++ b/scan_json/src/lib.rs
@@ -2,9 +2,9 @@
 
 pub mod action;
 pub mod error;
+pub mod idtransform;
 pub mod matcher;
 pub mod scan;
-pub mod idtransform;
 
 pub use action::{BoxedAction, BoxedEndAction, BoxedMatcher, StreamOp, Trigger};
 pub use error::{Error, Result};

--- a/scan_json/src/lib.rs
+++ b/scan_json/src/lib.rs
@@ -4,6 +4,7 @@ pub mod action;
 pub mod error;
 pub mod matcher;
 pub mod scan;
+pub mod idtransform;
 
 pub use action::{BoxedAction, BoxedEndAction, BoxedMatcher, StreamOp, Trigger};
 pub use error::{Error, Result};

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -1,0 +1,43 @@
+use rjiter::RJiter;
+use scan_json::idtransform::idtransform;
+
+#[test]
+fn idt_atomic_on_top() {
+    let input = r#"
+        null
+        true false
+        42 3.14
+        "hello"
+    "#;
+
+    let mut reader = input.as_bytes();
+    let mut buffer = vec![0u8; 16];
+    let mut rjiter = RJiter::new(&mut reader, &mut buffer);
+    let mut writer = Vec::new();
+
+    //
+    // Apply
+    //
+    idtransform(&mut rjiter, &mut writer); // null
+    writer.push(b' ');
+    idtransform(&mut rjiter, &mut writer); // true
+    writer.push(b' ');
+    idtransform(&mut rjiter, &mut writer); // false
+    writer.push(b' ');
+    idtransform(&mut rjiter, &mut writer); // 42
+    writer.push(b' ');
+    idtransform(&mut rjiter, &mut writer); // 3.14
+    writer.push(b' ');
+    idtransform(&mut rjiter, &mut writer); // "hello"
+
+    //
+    // Assert
+    //
+    let output = String::from_utf8(writer).unwrap();
+    let expected = input.split_whitespace().collect::<Vec<&str>>().join(" ");
+    assert_eq!(
+        output.trim(),
+        expected,
+        "Output should match input after idtransform. Output: {output}"
+    );
+}

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -215,7 +215,7 @@ fn idt_deeply_nested() {
 }
 
 #[test]
-fn test_idtransform_long_strings() {
+fn idt_long_strings() {
     let input = r#"
         {
             "long_key": "this_is_a_much_longer_string_value_that_spans_multiple_words_and_includes_punctuation!",
@@ -227,6 +227,35 @@ fn test_idtransform_long_strings() {
 
     let mut reader = input.as_bytes();
     let mut buffer = vec![0u8; 16];
+    let rjiter = RJiter::new(&mut reader, &mut buffer);
+    let rjiter_cell = RefCell::new(rjiter);
+    let mut writer = Vec::new();
+
+    idtransform(&rjiter_cell, &mut writer).unwrap();
+
+    let output = String::from_utf8(writer).unwrap();
+    let expected = input.split_whitespace().collect::<Vec<&str>>().join("");
+    assert_eq!(
+        output.trim(),
+        expected,
+        "Output should match input after idtransform. Output: {output}"
+    );
+}
+
+#[test]
+fn idt_special_symbols() {
+    let input = r#"
+        {
+            "key!@#$%": "value!@#$%",
+            "unicode★": "symbols★",
+            "escaped\"quotes\"": "with\"quotes\"",
+            "back\\slash": "with\\slash",
+            "control\n\t\r": "chars\n\t\r"
+        }
+    "#;
+
+    let mut reader = input.as_bytes();
+    let mut buffer = vec![0u8; 32];
     let rjiter = RJiter::new(&mut reader, &mut buffer);
     let rjiter_cell = RefCell::new(rjiter);
     let mut writer = Vec::new();

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -1,7 +1,6 @@
-use std::cell::RefCell;
-
 use rjiter::RJiter;
 use scan_json::idtransform::idtransform;
+use std::cell::RefCell;
 
 #[test]
 fn idt_atomic_on_top() {
@@ -19,23 +18,9 @@ fn idt_atomic_on_top() {
     let mut writer = Vec::new();
 
     //
-    // Apply
+    // Apply and assert
     //
-    idtransform(&rjiter_cell, &mut writer).unwrap(); // null
-    writer.push(b' ');
-    idtransform(&rjiter_cell, &mut writer).unwrap(); // true
-    writer.push(b' ');
-    idtransform(&rjiter_cell, &mut writer).unwrap(); // false
-    writer.push(b' ');
-    idtransform(&rjiter_cell, &mut writer).unwrap(); // 42
-    writer.push(b' ');
-    idtransform(&rjiter_cell, &mut writer).unwrap(); // 3.14
-    writer.push(b' ');
-    idtransform(&rjiter_cell, &mut writer).unwrap(); // "hello"
-
-    //
-    // Assert
-    //
+    idtransform(&rjiter_cell, &mut writer).unwrap();
     let output = String::from_utf8(writer).unwrap();
     let expected = input.split_whitespace().collect::<Vec<&str>>().join(" ");
     assert_eq!(

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -116,6 +116,35 @@ fn idt_object_in_object() {
 }
 
 #[test]
+fn idt_array_in_array() {
+    let input = r#"
+        [
+            [1, 2, 3],
+            ["a", "b", "c"],
+            [true, false, null]
+        ]
+    "#;
+
+    let mut reader = input.as_bytes();
+    let mut buffer = vec![0u8; 16];
+    let rjiter = RJiter::new(&mut reader, &mut buffer);
+    let rjiter_cell = RefCell::new(rjiter);
+    let mut writer = Vec::new();
+
+    //
+    // Apply and assert
+    //
+    idtransform(&rjiter_cell, &mut writer).unwrap();
+    let output = String::from_utf8(writer).unwrap();
+    let expected = input.split_whitespace().collect::<Vec<&str>>().join("");
+    assert_eq!(
+        output.trim(),
+        expected,
+        "Output should match input after idtransform. Output: {output}"
+    );
+}
+
+#[test]
 fn idt_deeply_nested() {
     let input = r#"
         {

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -93,7 +93,30 @@ fn idt_atomic_in_array() {
 }
 
 #[test]
-fn idt_nested_object() {
+fn idt_object_in_object() {
+    let input = r#"{ "foo": { "bar": "baz" } }"#;
+
+    let mut reader = input.as_bytes();
+    let mut buffer = vec![0u8; 16];
+    let rjiter = RJiter::new(&mut reader, &mut buffer);
+    let rjiter_cell = RefCell::new(rjiter);
+    let mut writer = Vec::new();
+
+    //
+    // Apply and assert
+    //
+    idtransform(&rjiter_cell, &mut writer).unwrap();
+    let output = String::from_utf8(writer).unwrap();
+    let expected = input.split_whitespace().collect::<Vec<&str>>().join("");
+    assert_eq!(
+        output.trim(),
+        expected,
+        "Output should match input after idtransform. Output: {output}"
+    );
+}
+
+#[test]
+fn idt_deeply_nested() {
     let input = r#"
         {
             "name": "John",
@@ -150,11 +173,14 @@ fn idt_nested_object() {
     //
     idtransform(&rjiter_cell, &mut writer).unwrap();
     let output = String::from_utf8(writer).unwrap();
-    let expected = input.split_whitespace().collect::<Vec<&str>>().join("").replace("}{\"x", "} {\"x");
+    let expected = input
+        .split_whitespace()
+        .collect::<Vec<&str>>()
+        .join("")
+        .replace("}{\"x", "} {\"x");
     assert_eq!(
         output.trim(),
         expected,
         "Output should match input after idtransform. Output: {output}"
     );
 }
-

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use rjiter::RJiter;
 use scan_json::idtransform::idtransform;
 
@@ -12,23 +14,24 @@ fn idt_atomic_on_top() {
 
     let mut reader = input.as_bytes();
     let mut buffer = vec![0u8; 16];
-    let mut rjiter = RJiter::new(&mut reader, &mut buffer);
+    let rjiter = RJiter::new(&mut reader, &mut buffer);
+    let rjiter_cell = RefCell::new(rjiter);
     let mut writer = Vec::new();
 
     //
     // Apply
     //
-    idtransform(&mut rjiter, &mut writer); // null
+    idtransform(&rjiter_cell, &mut writer).unwrap(); // null
     writer.push(b' ');
-    idtransform(&mut rjiter, &mut writer); // true
+    idtransform(&rjiter_cell, &mut writer).unwrap(); // true
     writer.push(b' ');
-    idtransform(&mut rjiter, &mut writer); // false
+    idtransform(&rjiter_cell, &mut writer).unwrap(); // false
     writer.push(b' ');
-    idtransform(&mut rjiter, &mut writer); // 42
+    idtransform(&rjiter_cell, &mut writer).unwrap(); // 42
     writer.push(b' ');
-    idtransform(&mut rjiter, &mut writer); // 3.14
+    idtransform(&rjiter_cell, &mut writer).unwrap(); // 3.14
     writer.push(b' ');
-    idtransform(&mut rjiter, &mut writer); // "hello"
+    idtransform(&rjiter_cell, &mut writer).unwrap(); // "hello"
 
     //
     // Assert

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -91,3 +91,70 @@ fn idt_atomic_in_array() {
         "Output should match input after idtransform. Output: {output}"
     );
 }
+
+#[test]
+fn idt_nested_object() {
+    let input = r#"
+        {
+            "name": "John",
+            "age": 42,
+            "address": {
+                "street": "123 Main St",
+                "city": "Anytown",
+                "country": "USA",
+                "coordinates": {
+                    "lat": 40.7128,
+                    "long": -74.0060
+                }
+            },
+            "contacts": [
+                {
+                    "type": "email",
+                    "value": "john@example.com",
+                    "tags": ["personal", "primary"]
+                },
+                {
+                    "type": "phone",
+                    "value": "+1-555-123-4567",
+                    "tags": ["work"],
+                    "hours": {
+                        "mon-fri": "9-5",
+                        "sat-sun": "closed"
+                    }
+                }
+            ],
+            "active": true,
+            "preferences": {
+                "notifications": {
+                    "email": true,
+                    "sms": false,
+                    "frequency": {
+                        "marketing": "weekly",
+                        "updates": "daily"
+                    }
+                }
+            }
+        }
+
+        {"x": [{}, {}, [[],[]]]}
+    "#;
+
+    let mut reader = input.as_bytes();
+    let mut buffer = vec![0u8; 32];
+    let rjiter = RJiter::new(&mut reader, &mut buffer);
+    let rjiter_cell = RefCell::new(rjiter);
+    let mut writer = Vec::new();
+
+    //
+    // Apply and assert
+    //
+    idtransform(&rjiter_cell, &mut writer).unwrap();
+    let output = String::from_utf8(writer).unwrap();
+    let expected = input.split_whitespace().collect::<Vec<&str>>().join("").replace("}{\"x", "} {\"x");
+    assert_eq!(
+        output.trim(),
+        expected,
+        "Output should match input after idtransform. Output: {output}"
+    );
+}
+

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -151,7 +151,7 @@ fn idt_deeply_nested() {
             "name": "John",
             "age": 42,
             "address": {
-                "street": "123 Main St",
+                "street": "123_Main_St",
                 "city": "Anytown",
                 "country": "USA",
                 "coordinates": {

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -29,3 +29,65 @@ fn idt_atomic_on_top() {
         "Output should match input after idtransform. Output: {output}"
     );
 }
+
+#[test]
+fn idt_atomic_in_object() {
+    let input = r#"
+        {
+            "null": null,
+            "bool": true,
+            "number": 42,
+            "float": 3.14,
+            "string": "hello"
+        }
+    "#;
+
+    let mut reader = input.as_bytes();
+    let mut buffer = vec![0u8; 16];
+    let rjiter = RJiter::new(&mut reader, &mut buffer);
+    let rjiter_cell = RefCell::new(rjiter);
+    let mut writer = Vec::new();
+
+    //
+    // Apply and assert
+    //
+    idtransform(&rjiter_cell, &mut writer).unwrap();
+    let output = String::from_utf8(writer).unwrap();
+    let expected = input.split_whitespace().collect::<Vec<&str>>().join("");
+    assert_eq!(
+        output.trim(),
+        expected,
+        "Output should match input after idtransform. Output: {output}"
+    );
+}
+
+#[test]
+fn idt_atomic_in_array() {
+    let input = r#"
+        [
+            null,
+            true,
+            42,
+            3.14,
+            "hello"
+        ]
+    "#;
+
+    let mut reader = input.as_bytes();
+    let mut buffer = vec![0u8; 16];
+    let rjiter = RJiter::new(&mut reader, &mut buffer);
+    let rjiter_cell = RefCell::new(rjiter);
+    let mut writer = Vec::new();
+
+    //
+    // Apply and assert
+    //
+    idtransform(&rjiter_cell, &mut writer).unwrap();
+    let output = String::from_utf8(writer).unwrap();
+    let expected = input.split_whitespace().collect::<Vec<&str>>().join("");
+    assert_eq!(
+        output.trim(),
+        expected,
+        "Output should match input after idtransform. Output: {output}"
+    );
+}

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -213,3 +213,31 @@ fn idt_deeply_nested() {
         "Output should match input after idtransform. Output: {output}"
     );
 }
+
+#[test]
+fn test_idtransform_long_strings() {
+    let input = r#"
+        {
+            "long_key": "this_is_a_much_longer_string_value_that_spans_multiple_words_and_includes_punctuation!",
+            "array": [
+                "another_lengthy_string_value_in_the_array_context_that_spans_multiple_words_and_includes_punctuation!"
+            ]
+        }
+    "#;
+
+    let mut reader = input.as_bytes();
+    let mut buffer = vec![0u8; 16];
+    let rjiter = RJiter::new(&mut reader, &mut buffer);
+    let rjiter_cell = RefCell::new(rjiter);
+    let mut writer = Vec::new();
+
+    idtransform(&rjiter_cell, &mut writer).unwrap();
+
+    let output = String::from_utf8(writer).unwrap();
+    let expected = input.split_whitespace().collect::<Vec<&str>>().join("");
+    assert_eq!(
+        output.trim(),
+        expected,
+        "Output should match input after idtransform. Output: {output}"
+    );
+}

--- a/scan_json/tests/scan_test.rs
+++ b/scan_json/tests/scan_test.rs
@@ -2,8 +2,8 @@ use std::cell::RefCell;
 use std::io::Write;
 
 use ::scan_json::action::{BoxedAction, BoxedEndAction, StreamOp, Trigger};
-use ::scan_json::matcher::{Matcher, Name, ParentAndName, ParentParentAndName};
-use ::scan_json::{scan, ContextFrame};
+use ::scan_json::matcher::{Name, ParentAndName, ParentParentAndName};
+use ::scan_json::scan;
 use rjiter::{jiter::Peek, RJiter};
 
 #[test]
@@ -960,95 +960,4 @@ data: [DONE]
     let writer_cell = scan_llm_output(json);
     let message = String::from_utf8(writer_cell.borrow().to_vec()).unwrap();
     assert_eq!(message, "Hello! How can I assist you today?");
-}
-
-#[test]
-fn test_json_to_xml() {
-    let json_data = r#"
-{
-    "name": "John Doe", 
-    "age": 43,
-    "phones": {
-        "phone": "+44 1234567",
-        "phone": "+44 2345678"
-    }
-}"#;
-
-    let mut reader = json_data.as_bytes();
-    let mut buffer = vec![0u8; 16];
-    let rjiter = RJiter::new(&mut reader, &mut buffer);
-    let writer_cell = RefCell::new(Vec::new());
-
-    struct SideEffectMatcher<'a> {
-        tag_infix: Option<u8>,
-        writer_cell: &'a RefCell<Vec<u8>>,
-    }
-
-    impl<'a> Matcher for SideEffectMatcher<'a> {
-        fn matches(&self, name: &str, _context: &[ContextFrame]) -> bool {
-            let mut writer = self.writer_cell.borrow_mut();
-            writer.write_all(b"<").unwrap();
-            if let Some(tag_infix) = self.tag_infix {
-                writer.write_all(&[tag_infix]).unwrap();
-            }
-            writer.write_all(name.as_bytes()).unwrap();
-            writer.write_all(b">").unwrap();
-            true
-        }
-    }
-
-    impl<'a> std::fmt::Debug for SideEffectMatcher<'a> {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "SideEffectMatcher {{ tag_infix: {:?} }}", self.tag_infix)
-        }
-    }
-
-    let begin_tag: Trigger<BoxedAction<dyn Write>> = Trigger::new(
-        Box::new(SideEffectMatcher {
-            tag_infix: None,
-            writer_cell: &writer_cell,
-        }),
-        Box::new(
-            |_rjiter_cell: &RefCell<RJiter>, _writer_cell: &RefCell<dyn Write>| StreamOp::None,
-        ),
-    );
-    let on_value: Trigger<BoxedAction<dyn Write>> = Trigger::new(
-        Box::new(Name::new("#atom".to_string())),
-        Box::new(
-            |rjiter_cell: &RefCell<RJiter>, writer_cell: &RefCell<dyn Write>| {
-                let mut rjiter = rjiter_cell.borrow_mut();
-                let mut writer = writer_cell.borrow_mut();
-                let peek = rjiter.peek().unwrap();
-                if peek == Peek::String {
-                    rjiter.write_long_bytes(&mut *writer).unwrap();
-                    return StreamOp::ValueIsConsumed;
-                }
-                let maybe_number = rjiter.next_number_bytes();
-                if let Ok(as_bytes) = maybe_number {
-                    writer.write_all(as_bytes).unwrap();
-                    return StreamOp::ValueIsConsumed;
-                }
-                StreamOp::None
-            },
-        ),
-    );
-    let end_tag: Trigger<BoxedEndAction<dyn Write>> = Trigger::new(
-        Box::new(SideEffectMatcher {
-            tag_infix: Some(b'/'),
-            writer_cell: &writer_cell,
-        }),
-        Box::new(|_writer: &RefCell<dyn Write>| Ok(())),
-    );
-
-    scan(
-        &vec![on_value, begin_tag],
-        &vec![end_tag],
-        &vec![],
-        &RefCell::new(rjiter),
-        &writer_cell,
-    )
-    .unwrap();
-
-    let message = String::from_utf8(writer_cell.borrow().to_vec()).unwrap();
-    assert_eq!(message, "<#object><name>John Doe</name><age>43</age><phones><phone>+44 1234567</phone><phone>+44 2345678</phone></phones></#object>");
 }


### PR DESCRIPTION
- New functions: `idtransform` and `copy_atom`
- Document the new functionality
- Add `IOError` to `ScanError`
- Delete `json_to_xml` test

close #65 