### PR TITLE
Sj68 id transform stop early

### DIFF
--- a/scan_json/Cargo.toml
+++ b/scan_json/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scan_json"
-version = "1.0.3"
+version = "1.1.0"
 edition = "2021"
 authors = ["Oleg Parashchenko <olpa@uucode.com>"]
 description = "React to elements in a JSON stream"
@@ -10,6 +10,7 @@ homepage = "https://github.com/olpa/streaming_json"
 repository = "https://github.com/olpa/streaming_json"
 keywords = ["json"]
 categories = ["parser-implementations", "parsing"]
+
 [lib]
 crate-type = ["lib"]
 

--- a/scan_json/README.md
+++ b/scan_json/README.md
@@ -79,7 +79,7 @@ use std::cell::RefCell;
 use std::io::Write;
 use scan_json::scan;
 use scan_json::{Name, ParentAndName, BoxedAction, BoxedEndAction, StreamOp, Trigger, rjiter::RJiter};
-use scan_json::ScanOptions;
+use scan_json::Options;
 
 
 fn scan_llm_output(json: &str) -> RefCell<Vec<u8>> {
@@ -127,7 +127,7 @@ fn scan_llm_output(json: &str) -> RefCell<Vec<u8>> {
         &vec![end_message],
         &rjiter_cell,
         &writer_cell,
-        ScanOptions {
+        &Options {
             sse_tokens: vec!["data:".to_string(), "DONE".to_string()],
             stop_early: false,
         },

--- a/scan_json/README.md
+++ b/scan_json/README.md
@@ -2,8 +2,9 @@
 
 Start processing JSON before the entire JSON document is available.
 
-- [crate](https://crates.io/crates/scan_json)
-- [documentation](https://docs.rs/scan_json/)
+- [`scan_json` on crates.io](https://crates.io/crates/scan_json)
+- [Documentation on docs.rs](https://docs.rs/scan_json/)
+- Entry point: [`crate::scan()`]
 
 
 ## Concepts
@@ -58,6 +59,8 @@ The identity transformation copies JSON input to output, retaining the original 
 
 The function [`crate::idtransform::idtransform()`] is not just a library function,
 but also an example of advanced `scan` use. Read the source code for details.
+
+Additionally, the function [`crate::idtransform::copy_atom()`] can be useful.
 
 
 ## Complete example: LLM output

--- a/scan_json/README.md
+++ b/scan_json/README.md
@@ -79,6 +79,7 @@ use std::cell::RefCell;
 use std::io::Write;
 use scan_json::scan;
 use scan_json::{Name, ParentAndName, BoxedAction, BoxedEndAction, StreamOp, Trigger, rjiter::RJiter};
+use scan_json::ScanOptions;
 
 
 fn scan_llm_output(json: &str) -> RefCell<Vec<u8>> {
@@ -124,9 +125,12 @@ fn scan_llm_output(json: &str) -> RefCell<Vec<u8>> {
     scan(
         &vec![begin_message, content],
         &vec![end_message],
-        &vec!["data:", "DONE"],
         &rjiter_cell,
         &writer_cell,
+        ScanOptions {
+            sse_tokens: vec!["data:".to_string(), "DONE".to_string()],
+            stop_early: false,
+        },
     )
     .unwrap();
 

--- a/scan_json/changelog.md
+++ b/scan_json/changelog.md
@@ -1,10 +1,12 @@
-## [1.0.3] - 2025-MM-DD
+## [1.1.0] - 2025-MM-DD
 
+- Change interface of the `scan` function
+- Implement identity transformation `idtransform` and provide `copy_atom`
 - Allow triggering on arrays
 - Allow triggering on basic values (strings, numbers, booleans, null)
 - Trigger on all objects, not only on unnamed in array context
+- An option to stop as soon as possible instead of scanning the whole stream
 - Add `IOError` to `ScanError`
-- Add `idtransform` and `copy_atom`
 
 
 ## [1.0.2] - 2025-05-03

--- a/scan_json/src/error.rs
+++ b/scan_json/src/error.rs
@@ -8,6 +8,7 @@
 /// - `UnbalancedJson`: JSON structure is not properly balanced at the given position
 /// - `InternalError`: Internal processing error at the given position with message
 /// - `MaxNestingExceeded`: JSON nesting level exceeded maximum at given position
+/// - `IOError`: IO error when writing to the output stream. Reading errors are inside `RJiterError`
 #[derive(Debug)]
 pub enum Error {
     RJiterError(rjiter::Error),
@@ -16,7 +17,7 @@ pub enum Error {
     InternalError(usize, String),
     MaxNestingExceeded(usize, usize),
     ActionError(Box<dyn std::error::Error>, usize),
-    IOError(std::io::Error), // for writing in id-transform; reading errors are inside RJiterError
+    IOError(std::io::Error),
 }
 
 impl std::error::Error for Error {}

--- a/scan_json/src/idtransform.rs
+++ b/scan_json/src/idtransform.rs
@@ -29,7 +29,7 @@ use crate::matcher::Matcher;
 use crate::StreamOp;
 use crate::{
     rjiter::jiter::Peek, scan, scan::ContextFrame, Error as ScanError, Name as NameMatcher, RJiter,
-    Result as ScanResult,
+    Result as ScanResult, ScanOptions,
 };
 use crate::{BoxedAction, BoxedEndAction, Trigger};
 use std::cell::RefCell;
@@ -343,9 +343,9 @@ pub fn idtransform(rjiter_cell: &RefCell<RJiter>, writer: &mut dyn Write) -> Sca
     let result = scan(
         &[trigger_atom, trigger_object, trigger_array, trigger_key],
         &[trigger_object_end, trigger_array_end],
-        &[],
         rjiter_cell,
         &idt_cell,
+        ScanOptions::new(),
     );
     #[allow(clippy::let_and_return)]
     result

--- a/scan_json/src/idtransform.rs
+++ b/scan_json/src/idtransform.rs
@@ -345,7 +345,10 @@ pub fn idtransform(rjiter_cell: &RefCell<RJiter>, writer: &mut dyn Write) -> Sca
         &[trigger_object_end, trigger_array_end],
         rjiter_cell,
         &idt_cell,
-        ScanOptions::new(),
+        ScanOptions {
+            sse_tokens: vec![],
+            stop_early: true,
+        },
     );
     #[allow(clippy::let_and_return)]
     result

--- a/scan_json/src/idtransform.rs
+++ b/scan_json/src/idtransform.rs
@@ -28,8 +28,8 @@
 use crate::matcher::Matcher;
 use crate::StreamOp;
 use crate::{
-    rjiter::jiter::Peek, scan, scan::ContextFrame, Error as ScanError, Name as NameMatcher, RJiter,
-    Result as ScanResult, ScanOptions,
+    rjiter::jiter::Peek, scan, scan::ContextFrame, Error as ScanError, Name as NameMatcher,
+    Options, RJiter, Result as ScanResult,
 };
 use crate::{BoxedAction, BoxedEndAction, Trigger};
 use std::cell::RefCell;
@@ -345,7 +345,7 @@ pub fn idtransform(rjiter_cell: &RefCell<RJiter>, writer: &mut dyn Write) -> Sca
         &[trigger_object_end, trigger_array_end],
         rjiter_cell,
         &idt_cell,
-        ScanOptions {
+        &Options {
             sse_tokens: vec![],
             stop_early: true,
         },

--- a/scan_json/src/lib.rs
+++ b/scan_json/src/lib.rs
@@ -11,7 +11,7 @@ pub use error::{Error, Result};
 pub use matcher::{
     DebugPrinter as MatcherDebugPrinter, Matcher, Name, ParentAndName, ParentParentAndName,
 };
-pub use scan::{scan, ContextFrame, ScanOptions};
+pub use scan::{scan, ContextFrame, Options};
 
 pub use rjiter;
 pub use rjiter::jiter;

--- a/scan_json/src/lib.rs
+++ b/scan_json/src/lib.rs
@@ -11,7 +11,7 @@ pub use error::{Error, Result};
 pub use matcher::{
     DebugPrinter as MatcherDebugPrinter, Matcher, Name, ParentAndName, ParentParentAndName,
 };
-pub use scan::{scan, ContextFrame};
+pub use scan::{scan, ContextFrame, ScanOptions};
 
 pub use rjiter;
 pub use rjiter::jiter;

--- a/scan_json/src/scan.rs
+++ b/scan_json/src/scan.rs
@@ -431,11 +431,6 @@ pub fn scan<T: ?Sized>(
             }
         }
 
-        // Check if we should stop early
-        if options.stop_early {
-            break;
-        }
-
         return Err(ScanError::UnhandledPeek(peeked, rjiter.current_index()));
     }
 

--- a/scan_json/src/scan.rs
+++ b/scan_json/src/scan.rs
@@ -16,7 +16,7 @@ const MAX_NESTING: usize = 20;
 pub struct ScanOptions {
     /// List of SSE tokens to ignore at the top level
     pub sse_tokens: Vec<String>,
-    /// Whether to stop scanning early when encountering certain conditions
+    /// Whether to stop scanning as soon as possible, or scan the complete JSON stream
     pub stop_early: bool,
 }
 
@@ -30,31 +30,9 @@ impl Default for ScanOptions {
 }
 
 impl ScanOptions {
-    /// Create a new `ScanOptions` with default values
     #[allow(clippy::must_use_candidate)]
     pub fn new() -> Self {
         Self::default()
-    }
-
-    /// Set the SSE tokens to ignore
-    #[allow(clippy::must_use_candidate)]
-    pub fn with_sse_tokens(mut self, sse_tokens: Vec<String>) -> Self {
-        self.sse_tokens = sse_tokens;
-        self
-    }
-
-    /// Set the stop_early option
-    #[allow(clippy::must_use_candidate)]
-    pub fn with_stop_early(mut self, stop_early: bool) -> Self {
-        self.stop_early = stop_early;
-        self
-    }
-
-    /// Set the SSE tokens from string slices
-    #[allow(clippy::must_use_candidate)]
-    pub fn with_sse_tokens_str(mut self, sse_tokens: &[&str]) -> Self {
-        self.sse_tokens = sse_tokens.iter().map(|s| s.to_string()).collect();
-        self
     }
 }
 

--- a/scan_json/src/scan.rs
+++ b/scan_json/src/scan.rs
@@ -12,24 +12,15 @@ use std::io;
 const MAX_NESTING: usize = 20;
 
 /// Options for configuring the scan behavior
-#[derive(Debug, Clone)]
-pub struct ScanOptions {
+#[derive(Debug, Clone, Default)]
+pub struct Options {
     /// List of SSE tokens to ignore at the top level
     pub sse_tokens: Vec<String>,
     /// Whether to stop scanning as soon as possible, or scan the complete JSON stream
     pub stop_early: bool,
 }
 
-impl Default for ScanOptions {
-    fn default() -> Self {
-        Self {
-            sse_tokens: Vec::new(),
-            stop_early: false,
-        }
-    }
-}
-
-impl ScanOptions {
+impl Options {
     #[allow(clippy::must_use_candidate)]
     pub fn new() -> Self {
         Self::default()
@@ -282,7 +273,7 @@ pub fn scan<T: ?Sized>(
     triggers_end: &[Trigger<BoxedEndAction<T>>],
     rjiter_cell: &RefCell<RJiter>,
     baton_cell: &RefCell<T>,
-    options: ScanOptions,
+    options: &Options,
 ) -> ScanResult<()> {
     let mut context: Vec<ContextFrame> = Vec::new();
     let mut cur_level = ContextFrame {

--- a/scan_json/src/scan.rs
+++ b/scan_json/src/scan.rs
@@ -292,7 +292,14 @@ pub fn scan<T: ?Sized>(
         is_in_array: false,
     };
 
+    let mut is_progressed = false;
+
     'main_loop: loop {
+        if is_progressed && options.stop_early && context.is_empty() {
+            break;
+        }
+        is_progressed = true;
+
         let mut peeked = None;
 
         if cur_level.is_in_object {

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -1,6 +1,7 @@
 use rjiter::RJiter;
 use scan_json::idtransform::idtransform;
 use std::cell::RefCell;
+use std::io::Write;
 
 #[test]
 fn idt_atomic_on_top() {
@@ -20,11 +21,15 @@ fn idt_atomic_on_top() {
     //
     // Apply and assert
     //
-    idtransform(&rjiter_cell, &mut writer).unwrap();
+    for _ in 0..input.split_whitespace().count() {
+        idtransform(&rjiter_cell, &mut writer).unwrap();
+        writer.write_all(b" ").unwrap();
+    }
     let output = String::from_utf8(writer).unwrap();
+    let output = output.trim();
     let expected = input.split_whitespace().collect::<Vec<&str>>().join(" ");
     assert_eq!(
-        output.trim(),
+        output,
         expected,
         "Output should match input after idtransform. Output: {output}"
     );
@@ -185,10 +190,9 @@ fn idt_deeply_nested() {
                         "updates": "daily"
                     }
                 }
-            }
+            },
+            "x": [{}, {}, [[],[]]]
         }
-
-        {"x": [{}, {}, [[],[]]]}
     "#;
 
     let mut reader = input.as_bytes();

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -29,8 +29,7 @@ fn idt_atomic_on_top() {
     let output = output.trim();
     let expected = input.split_whitespace().collect::<Vec<&str>>().join(" ");
     assert_eq!(
-        output,
-        expected,
+        output, expected,
         "Output should match input after idtransform. Output: {output}"
     );
 }

--- a/scan_json/tests/idtransform_test.rs
+++ b/scan_json/tests/idtransform_test.rs
@@ -272,13 +272,12 @@ fn idt_special_symbols() {
 }
 
 #[test]
-#[ignore] // FIXME
 fn idt_stop_after_object() {
     let input = r#"
         {
             "key1": "value1",
             "key2": "value2"
-        },
+        }
         {
             "next_obj_key": "next_obj_value" 
         }
@@ -310,6 +309,6 @@ fn idt_stop_after_object() {
     // Act: RJiter should be able to read the next key-value pair
     //
     let mut rjiter = rjiter_cell.borrow_mut();
-    let key = rjiter.next_key().unwrap();
+    let key = rjiter.next_object().unwrap();
     assert_eq!(key, Some("next_obj_key"));
 }

--- a/scan_json/tests/scan_test.rs
+++ b/scan_json/tests/scan_test.rs
@@ -140,7 +140,10 @@ fn test_skip_sse_tokens() {
     let mut buffer = vec![0u8; 16];
     let rjiter = RJiter::new(&mut reader, &mut buffer);
 
-    let options = ScanOptions::new().with_sse_tokens_str(&["data:", "DONE"]);
+    let options = ScanOptions {
+        sse_tokens: vec!["data:".to_string(), "DONE".to_string()],
+        stop_early: false,
+    };
     scan(
         &vec![],
         &vec![],
@@ -166,7 +169,14 @@ fn test_call_begin_dont_touch_value() {
     });
     let triggers = vec![Trigger { matcher, action }];
 
-    scan(&triggers, &vec![], &RefCell::new(rjiter), &state, ScanOptions::new()).unwrap();
+    scan(
+        &triggers,
+        &vec![],
+        &RefCell::new(rjiter),
+        &state,
+        ScanOptions::new(),
+    )
+    .unwrap();
     assert!(*state.borrow(), "Trigger should have been called for 'foo'");
 }
 
@@ -190,7 +200,14 @@ fn test_call_begin_consume_value() {
         });
     let triggers = vec![Trigger { matcher, action }];
 
-    scan(&triggers, &vec![], &RefCell::new(rjiter), &state, ScanOptions::new()).unwrap();
+    scan(
+        &triggers,
+        &vec![],
+        &RefCell::new(rjiter),
+        &state,
+        ScanOptions::new(),
+    )
+    .unwrap();
     assert!(*state.borrow(), "Trigger should have been called for 'foo'");
 }
 
@@ -822,7 +839,13 @@ fn atoms_stream_op_return_values() {
         action: begin_action,
     }];
 
-    let result = scan(&triggers, &vec![], &rjiter_cell, &writer_cell, ScanOptions::new());
+    let result = scan(
+        &triggers,
+        &vec![],
+        &rjiter_cell,
+        &writer_cell,
+        ScanOptions::new(),
+    );
 
     // Check the output
     let message = String::from_utf8(writer_cell.borrow().to_vec()).unwrap();
@@ -879,7 +902,10 @@ fn scan_llm_output(json: &str) -> RefCell<Vec<u8>> {
         &vec![end_message],
         &RefCell::new(rjiter),
         &writer_cell,
-        ScanOptions::new().with_sse_tokens_str(&["data:", "DONE"]),
+        ScanOptions {
+            sse_tokens: vec!["data:".to_string(), "DONE".to_string()],
+            stop_early: false,
+        },
     )
     .unwrap();
 

--- a/scan_json/tests/scan_test.rs
+++ b/scan_json/tests/scan_test.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use ::scan_json::action::{BoxedAction, BoxedEndAction, StreamOp, Trigger};
 use ::scan_json::matcher::{Name, ParentAndName, ParentParentAndName};
-use ::scan_json::scan;
+use ::scan_json::{scan, ScanOptions};
 use rjiter::{jiter::Peek, RJiter};
 
 #[test]
@@ -16,9 +16,9 @@ fn test_scan_json_empty_input() {
     scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
+        ScanOptions::new(),
     )
     .unwrap();
 }
@@ -34,9 +34,9 @@ fn test_scan_json_top_level_types() {
     scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
+        ScanOptions::new(),
     )
     .unwrap();
 }
@@ -52,9 +52,9 @@ fn test_scan_json_simple_object() {
     scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
+        ScanOptions::new(),
     )
     .unwrap();
 }
@@ -70,9 +70,9 @@ fn test_scan_json_simple_array() {
     scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
+        ScanOptions::new(),
     )
     .unwrap();
 }
@@ -109,9 +109,9 @@ fn test_scan_json_nested_complex() {
     scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
+        ScanOptions::new(),
     )
     .unwrap();
 }
@@ -126,9 +126,9 @@ fn skip_long_string() {
     scan(
         &vec![],
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
+        ScanOptions::new(),
     )
     .unwrap();
 }
@@ -140,13 +140,13 @@ fn test_skip_sse_tokens() {
     let mut buffer = vec![0u8; 16];
     let rjiter = RJiter::new(&mut reader, &mut buffer);
 
-    let sse_tokens = vec!["data:", "DONE"];
+    let options = ScanOptions::new().with_sse_tokens_str(&["data:", "DONE"]);
     scan(
         &vec![],
         &vec![],
-        &sse_tokens,
         &RefCell::new(rjiter),
         &RefCell::new(()),
+        options,
     )
     .unwrap();
 }
@@ -166,7 +166,7 @@ fn test_call_begin_dont_touch_value() {
     });
     let triggers = vec![Trigger { matcher, action }];
 
-    scan(&triggers, &vec![], &vec![], &RefCell::new(rjiter), &state).unwrap();
+    scan(&triggers, &vec![], &RefCell::new(rjiter), &state, ScanOptions::new()).unwrap();
     assert!(*state.borrow(), "Trigger should have been called for 'foo'");
 }
 
@@ -190,7 +190,7 @@ fn test_call_begin_consume_value() {
         });
     let triggers = vec![Trigger { matcher, action }];
 
-    scan(&triggers, &vec![], &vec![], &RefCell::new(rjiter), &state).unwrap();
+    scan(&triggers, &vec![], &RefCell::new(rjiter), &state, ScanOptions::new()).unwrap();
     assert!(*state.borrow(), "Trigger should have been called for 'foo'");
 }
 
@@ -219,9 +219,9 @@ fn test_call_end() {
     scan(
         &vec![],
         &triggers_end,
-        &vec![],
         &RefCell::new(rjiter),
         &state,
+        ScanOptions::new(),
     )
     .unwrap();
     assert_eq!(
@@ -266,9 +266,9 @@ fn notify_for_top_level_object() {
     scan(
         &triggers,
         &triggers_end,
-        &vec![],
         &RefCell::new(rjiter),
         &state,
+        ScanOptions::new(),
     )
     .unwrap();
 
@@ -314,9 +314,9 @@ fn notify_for_object_in_array() {
     scan(
         &triggers,
         &triggers_end,
-        &vec![],
         &RefCell::new(rjiter),
         &state,
+        ScanOptions::new(),
     )
     .unwrap();
 
@@ -366,9 +366,9 @@ fn notify_for_array() {
     scan(
         &triggers,
         &triggers_end,
-        &vec![],
         &RefCell::new(rjiter),
         &state,
+        ScanOptions::new(),
     )
     .unwrap();
 
@@ -420,9 +420,9 @@ fn client_can_consume_array() {
     scan(
         &triggers,
         &triggers_end,
-        &vec![],
         &RefCell::new(rjiter),
         &writer_cell,
+        ScanOptions::new(),
     )
     .unwrap();
 
@@ -464,9 +464,9 @@ fn several_arrays_top_level() {
     scan(
         &triggers,
         &triggers_end,
-        &vec![],
         &RefCell::new(rjiter),
         &writer_cell,
+        ScanOptions::new(),
     )
     .unwrap();
 
@@ -487,9 +487,9 @@ fn max_nesting_array() {
     let result = scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
+        ScanOptions::new(),
     );
     let e = result.unwrap_err();
     assert_eq!(
@@ -509,9 +509,9 @@ fn max_nesting_object() {
     let result = scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
+        ScanOptions::new(),
     );
     let e = result.unwrap_err();
     assert_eq!(
@@ -536,9 +536,9 @@ fn error_in_begin_action() {
     let result = scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
+        ScanOptions::new(),
     );
 
     let err = result.unwrap_err();
@@ -566,9 +566,9 @@ fn error_in_end_action() {
     let result = scan(
         &vec![],
         &triggers_end,
-        &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
+        ScanOptions::new(),
     );
 
     let err = result.unwrap_err();
@@ -610,9 +610,9 @@ fn several_objects_top_level() {
     scan(
         &triggers,
         &triggers_end,
-        &vec![],
         &RefCell::new(rjiter),
         &writer_cell,
+        ScanOptions::new(),
     )
     .unwrap();
 
@@ -650,9 +650,9 @@ fn match_in_array_context() {
     scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &writer_cell,
+        ScanOptions::new(),
     )
     .unwrap();
 
@@ -686,9 +686,9 @@ fn atoms_on_top_level() {
     let result = scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &writer_cell,
+        ScanOptions::new(),
     );
     assert!(result.is_ok());
 
@@ -729,9 +729,9 @@ fn atoms_in_array() {
     let result = scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &writer_cell,
+        ScanOptions::new(),
     );
     assert!(result.is_ok());
 
@@ -770,9 +770,9 @@ fn atoms_in_object() {
     let result = scan(
         &triggers,
         &vec![],
-        &vec![],
         &RefCell::new(rjiter),
         &writer_cell,
+        ScanOptions::new(),
     );
     assert!(result.is_ok());
 
@@ -822,7 +822,7 @@ fn atoms_stream_op_return_values() {
         action: begin_action,
     }];
 
-    let result = scan(&triggers, &vec![], &vec![], &rjiter_cell, &writer_cell);
+    let result = scan(&triggers, &vec![], &rjiter_cell, &writer_cell, ScanOptions::new());
 
     // Check the output
     let message = String::from_utf8(writer_cell.borrow().to_vec()).unwrap();
@@ -877,9 +877,9 @@ fn scan_llm_output(json: &str) -> RefCell<Vec<u8>> {
     scan(
         &vec![begin_message, content],
         &vec![end_message],
-        &vec!["data:", "DONE"],
         &RefCell::new(rjiter),
         &writer_cell,
+        ScanOptions::new().with_sse_tokens_str(&["data:", "DONE"]),
     )
     .unwrap();
 

--- a/scan_json/tests/scan_test.rs
+++ b/scan_json/tests/scan_test.rs
@@ -990,7 +990,7 @@ data: [DONE]
 
 #[test]
 fn stop_early() {
-    let input = "1 2 3 4 5";
+    let input = r#"{} [] {"foo: "bar}, [{}, []] 777 true}"#;
     let mut reader = input.as_bytes();
     let mut buffer = vec![0u8; 16];
 
@@ -1019,6 +1019,7 @@ fn stop_early() {
     let rjiter_cell = RefCell::new(rjiter);
 
     let triggers: Vec<Trigger<BoxedAction<()>>> = vec![];
+    for _ in 0..4 {
     scan(
         &triggers,
         &vec![],
@@ -1027,11 +1028,12 @@ fn stop_early() {
         ScanOptions {
             sse_tokens: vec![],
             stop_early: true, // `true`
-        },
-    )
-    .unwrap();
+            },
+        )
+        .unwrap();
+    }
 
-    // Verify we can still read the next item
+    // Verify we can still read the next item, which is 777
     let mut rjiter = rjiter_cell.borrow_mut();
-    assert_eq!(rjiter.next_int().unwrap(), rjiter::jiter::NumberInt::Int(2));
+    assert_eq!(rjiter.next_int().unwrap(), rjiter::jiter::NumberInt::Int(777));
 }

--- a/scan_json/tests/scan_test.rs
+++ b/scan_json/tests/scan_test.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 
 use ::scan_json::action::{BoxedAction, BoxedEndAction, StreamOp, Trigger};
 use ::scan_json::matcher::{Name, ParentAndName, ParentParentAndName};
-use ::scan_json::{scan, ScanOptions};
+use ::scan_json::{scan, Options};
 use rjiter::{jiter::Peek, RJiter};
 
 #[test]
@@ -18,7 +18,7 @@ fn test_scan_json_empty_input() {
         &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 }
@@ -36,7 +36,7 @@ fn test_scan_json_top_level_types() {
         &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 }
@@ -54,7 +54,7 @@ fn test_scan_json_simple_object() {
         &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 }
@@ -72,7 +72,7 @@ fn test_scan_json_simple_array() {
         &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 }
@@ -111,7 +111,7 @@ fn test_scan_json_nested_complex() {
         &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 }
@@ -128,7 +128,7 @@ fn skip_long_string() {
         &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 }
@@ -140,7 +140,7 @@ fn test_skip_sse_tokens() {
     let mut buffer = vec![0u8; 16];
     let rjiter = RJiter::new(&mut reader, &mut buffer);
 
-    let options = ScanOptions {
+    let options = Options {
         sse_tokens: vec!["data:".to_string(), "DONE".to_string()],
         stop_early: false,
     };
@@ -149,7 +149,7 @@ fn test_skip_sse_tokens() {
         &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
-        options,
+        &options,
     )
     .unwrap();
 }
@@ -174,7 +174,7 @@ fn test_call_begin_dont_touch_value() {
         &vec![],
         &RefCell::new(rjiter),
         &state,
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
     assert!(*state.borrow(), "Trigger should have been called for 'foo'");
@@ -205,7 +205,7 @@ fn test_call_begin_consume_value() {
         &vec![],
         &RefCell::new(rjiter),
         &state,
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
     assert!(*state.borrow(), "Trigger should have been called for 'foo'");
@@ -238,7 +238,7 @@ fn test_call_end() {
         &triggers_end,
         &RefCell::new(rjiter),
         &state,
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
     assert_eq!(
@@ -285,7 +285,7 @@ fn notify_for_top_level_object() {
         &triggers_end,
         &RefCell::new(rjiter),
         &state,
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 
@@ -333,7 +333,7 @@ fn notify_for_object_in_array() {
         &triggers_end,
         &RefCell::new(rjiter),
         &state,
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 
@@ -385,7 +385,7 @@ fn notify_for_array() {
         &triggers_end,
         &RefCell::new(rjiter),
         &state,
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 
@@ -439,7 +439,7 @@ fn client_can_consume_array() {
         &triggers_end,
         &RefCell::new(rjiter),
         &writer_cell,
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 
@@ -483,7 +483,7 @@ fn several_arrays_top_level() {
         &triggers_end,
         &RefCell::new(rjiter),
         &writer_cell,
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 
@@ -506,7 +506,7 @@ fn max_nesting_array() {
         &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
-        ScanOptions::new(),
+        &Options::new(),
     );
     let e = result.unwrap_err();
     assert_eq!(
@@ -528,7 +528,7 @@ fn max_nesting_object() {
         &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
-        ScanOptions::new(),
+        &Options::new(),
     );
     let e = result.unwrap_err();
     assert_eq!(
@@ -555,7 +555,7 @@ fn error_in_begin_action() {
         &vec![],
         &RefCell::new(rjiter),
         &RefCell::new(()),
-        ScanOptions::new(),
+        &Options::new(),
     );
 
     let err = result.unwrap_err();
@@ -585,7 +585,7 @@ fn error_in_end_action() {
         &triggers_end,
         &RefCell::new(rjiter),
         &RefCell::new(()),
-        ScanOptions::new(),
+        &Options::new(),
     );
 
     let err = result.unwrap_err();
@@ -629,7 +629,7 @@ fn several_objects_top_level() {
         &triggers_end,
         &RefCell::new(rjiter),
         &writer_cell,
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 
@@ -669,7 +669,7 @@ fn match_in_array_context() {
         &vec![],
         &RefCell::new(rjiter),
         &writer_cell,
-        ScanOptions::new(),
+        &Options::new(),
     )
     .unwrap();
 
@@ -705,7 +705,7 @@ fn atoms_on_top_level() {
         &vec![],
         &RefCell::new(rjiter),
         &writer_cell,
-        ScanOptions::new(),
+        &Options::new(),
     );
     assert!(result.is_ok());
 
@@ -748,7 +748,7 @@ fn atoms_in_array() {
         &vec![],
         &RefCell::new(rjiter),
         &writer_cell,
-        ScanOptions::new(),
+        &Options::new(),
     );
     assert!(result.is_ok());
 
@@ -789,7 +789,7 @@ fn atoms_in_object() {
         &vec![],
         &RefCell::new(rjiter),
         &writer_cell,
-        ScanOptions::new(),
+        &Options::new(),
     );
     assert!(result.is_ok());
 
@@ -844,7 +844,7 @@ fn atoms_stream_op_return_values() {
         &vec![],
         &rjiter_cell,
         &writer_cell,
-        ScanOptions::new(),
+        &Options::new(),
     );
 
     // Check the output
@@ -902,7 +902,7 @@ fn scan_llm_output(json: &str) -> RefCell<Vec<u8>> {
         &vec![end_message],
         &RefCell::new(rjiter),
         &writer_cell,
-        ScanOptions {
+        &Options {
             sse_tokens: vec!["data:".to_string(), "DONE".to_string()],
             stop_early: false,
         },
@@ -1004,7 +1004,7 @@ fn stop_early() {
         &vec![],
         &rjiter_cell,
         &RefCell::new(()),
-        ScanOptions {
+        &Options {
             sse_tokens: vec![],
             stop_early: false, // `false`
         },
@@ -1026,15 +1026,18 @@ fn stop_early() {
             &vec![],
             &rjiter_cell,
             &RefCell::new(()),
-            ScanOptions {
+            &Options {
                 sse_tokens: vec![],
                 stop_early: true, // `true`
-                },
-            )
-            .unwrap();
+            },
+        )
+        .unwrap();
     }
 
     // Verify we can still read the next item, which is 777
     let mut rjiter = rjiter_cell.borrow_mut();
-    assert_eq!(rjiter.next_int().unwrap(), rjiter::jiter::NumberInt::Int(777));
+    assert_eq!(
+        rjiter.next_int().unwrap(),
+        rjiter::jiter::NumberInt::Int(777)
+    );
 }

--- a/scan_json/tests/scan_test.rs
+++ b/scan_json/tests/scan_test.rs
@@ -990,7 +990,7 @@ data: [DONE]
 
 #[test]
 fn stop_early() {
-    let input = r#"{} [] {"foo: "bar}, [{}, []] 777 true}"#;
+    let input = r#"{} [] {"foo": "bar"} [{}, []] 777 true"#;
     let mut reader = input.as_bytes();
     let mut buffer = vec![0u8; 16];
 
@@ -1015,22 +1015,23 @@ fn stop_early() {
     rjiter_cell.borrow_mut().finish().unwrap();
 
     // Part 2: Process only first item when stop_early is true
+    let mut reader = input.as_bytes();
     let rjiter = RJiter::new(&mut reader, &mut buffer);
     let rjiter_cell = RefCell::new(rjiter);
 
     let triggers: Vec<Trigger<BoxedAction<()>>> = vec![];
     for _ in 0..4 {
-    scan(
-        &triggers,
-        &vec![],
-        &rjiter_cell,
-        &RefCell::new(()),
-        ScanOptions {
-            sse_tokens: vec![],
-            stop_early: true, // `true`
-            },
-        )
-        .unwrap();
+        scan(
+            &triggers,
+            &vec![],
+            &rjiter_cell,
+            &RefCell::new(()),
+            ScanOptions {
+                sse_tokens: vec![],
+                stop_early: true, // `true`
+                },
+            )
+            .unwrap();
     }
 
     // Verify we can still read the next item, which is 777


### PR DESCRIPTION
- Change `scan` interface: Introduce `Options`
- Bump the minor version
- The parameter `sse_tokens` is now in `Options`
- Add option: stop early instead of scanning the whole stream
- `idtransform` stops early

close #68 