### PR TITLE
Publish scan_json 1.1.0

### DIFF
--- a/scan_json/changelog.md
+++ b/scan_json/changelog.md
@@ -1,4 +1,4 @@
-## [1.1.0] - 2025-MM-DD
+## [1.1.0] - 2025-07-01
 
 - Change interface of the `scan` function
 - Implement identity transformation `idtransform` and provide `copy_atom`


### PR DESCRIPTION
Changelog:

- Change interface of the `scan` function
- Implement identity transformation `idtransform` and provide `copy_atom`
- Allow triggering on arrays
- Allow triggering on basic values (strings, numbers, booleans, null)
- Trigger on all objects, not only on unnamed in array context
- An option to stop as soon as possible instead of scanning the whole stream
- Add `IOError` to `ScanError`
