### PR TITLE
Implement dictionary interface foundation for BufVec

### DIFF
--- a/bufvec/plan.md
+++ b/bufvec/plan.md
@@ -88,7 +88,7 @@
 
 ---
 
-## Task 4: Dictionary Interface Foundation
+## Task 4: Dictionary Interface Foundation ✅ COMPLETED
 
 **Context**: Implement the key-value pairing convention where even indices are keys and odd indices are values.
 
@@ -110,6 +110,15 @@
 - Document dictionary convention clearly
 - Add dictionary usage examples to `README.md`
 - Update `doc/llms.txt` with dictionary patterns
+
+**Implementation Summary**:
+- Added helper methods: `is_key()`, `is_value()`, `has_unpaired_key()`, `pairs_count()`
+- Implemented `BufVecPairIter` that yields `(key, Option<value>)` tuples
+- Handles unpaired keys by returning `None` for missing values
+- Added comprehensive test coverage for all dictionary functionality
+- Updated module documentation with dictionary convention examples
+- Maintains full compatibility with existing vector interface
+- 8 new tests covering all dictionary scenarios: even/odd elements, empty vector, mixed usage
 
 ---
 


### PR DESCRIPTION
## Summary
- Implement key-value pairing convention where even indices are keys and odd indices are values
- Add helper methods: `is_key()`, `is_value()`, `has_unpaired_key()`, `pairs_count()`
- Implement `BufVecPairIter` that yields `(key, Option<value>)` tuples with proper handling of unpaired keys
- Apply clippy fixes for safer buffer access using `.get()` instead of direct slicing
- Add comprehensive test coverage with 8 new tests for all dictionary scenarios
- Update module documentation with dictionary convention examples
- Maintain full compatibility with existing vector interface

## Test plan
- [x] All existing tests continue to pass (27 tests total)
- [x] New dictionary functionality tests cover even/odd elements, empty vector, and mixed usage
- [x] Code passes strict clippy linting with pedantic rules
- [x] Documentation examples compile and execute correctly
- [x] Zero regressions in existing vector and iterator functionality

🤖 Generated with [Claude Code](https://claude.ai/code)