### PR TITLE
Implement stack interface for BufVec

### DIFF
--- a/bufvec/src/lib.rs
+++ b/bufvec/src/lib.rs
@@ -66,6 +66,52 @@
 //! assert_eq!(bufvec.get(1), b"alice123");
 //! ```
 //!
+//! # Stack Interface
+//!
+//! `BufVec` supports stack operations through methods like `push()`, `pop()`, and `top()`:
+//!
+//! ```
+//! # use bufvec::BufVec;
+//! let mut buffer = [0u8; 200];
+//! let mut bufvec = BufVec::with_default_max_slices(&mut buffer).unwrap();
+//!
+//! // Push elements onto the stack
+//! bufvec.push(b"first").unwrap();
+//! bufvec.push(b"second").unwrap();
+//! bufvec.push(b"third").unwrap();
+//!
+//! // Peek at the top element without removing it
+//! assert_eq!(bufvec.top(), b"third");
+//! assert_eq!(bufvec.len(), 3);
+//!
+//! // Pop elements in LIFO order
+//! assert_eq!(bufvec.pop(), b"third");
+//! assert_eq!(bufvec.pop(), b"second");
+//! assert_eq!(bufvec.pop(), b"first");
+//!
+//! assert!(bufvec.is_empty());
+//!
+//! // Safe variants for error handling
+//! assert!(bufvec.try_top().is_err());
+//! assert!(bufvec.try_pop().is_err());
+//! ```
+//!
+//! The stack interface maintains compatibility with vector operations:
+//!
+//! ```
+//! # use bufvec::BufVec;
+//! let mut buffer = [0u8; 200];
+//! let mut bufvec = BufVec::with_default_max_slices(&mut buffer).unwrap();
+//!
+//! // Mix stack and vector operations
+//! bufvec.push(b"stack_data").unwrap();
+//! bufvec.add(b"vector_data").unwrap();
+//!
+//! // Both interfaces work on the same underlying data
+//! assert_eq!(bufvec.get(0), b"stack_data");
+//! assert_eq!(bufvec.top(), b"vector_data");
+//! ```
+//!
 //! # Iterator Support
 //!
 //! `BufVec` implements standard Rust iterator patterns:
@@ -322,6 +368,44 @@ impl<'a> BufVec<'a> {
         self.count += 1;
 
         Ok(())
+    }
+
+    /// Pushes a slice onto the stack (alias for `add`).
+    ///
+    /// # Errors
+    ///
+    /// Returns `BufVecError::BufferOverflow` if:
+    /// - The maximum number of slices has been reached
+    /// - There is insufficient space in the buffer for the data
+    ///
+    /// # Panics
+    ///
+    /// May panic if buffer integrity is compromised (internal validation failure).
+    pub fn push(&mut self, data: &[u8]) -> Result<(), BufVecError> {
+        self.add(data)
+    }
+
+    /// Returns a reference to the top element of the stack (last element) without removing it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the stack is empty.
+    #[must_use]
+    pub fn top(&self) -> &[u8] {
+        assert!(self.count > 0, "Cannot peek at top of empty stack");
+        self.get(self.count - 1)
+    }
+
+    /// Tries to return a reference to the top element of the stack (last element) without removing it.
+    ///
+    /// # Errors
+    ///
+    /// Returns `BufVecError::EmptyVector` if the stack is empty.
+    pub fn try_top(&self) -> Result<&[u8], BufVecError> {
+        if self.count == 0 {
+            return Err(BufVecError::EmptyVector);
+        }
+        Ok(self.get(self.count - 1))
     }
 
     pub fn clear(&mut self) {
@@ -1183,5 +1267,164 @@ mod tests {
         assert_eq!(pairs.len(), 2);
         assert_eq!(pairs[0], (&b"key1"[..], Some(&b"value1"[..])));
         assert_eq!(pairs[1], (&b"key2"[..], Some(&b"replacedvalue2"[..])));
+    }
+
+    #[test]
+    fn test_stack_push_operations() {
+        let mut buffer = [0u8; 200];
+        let mut bufvec = BufVec::with_default_max_slices(&mut buffer).unwrap();
+
+        assert!(bufvec.is_empty());
+        assert_eq!(bufvec.len(), 0);
+
+        // Test push operations
+        assert!(bufvec.push(b"first").is_ok());
+        assert_eq!(bufvec.len(), 1);
+        assert!(!bufvec.is_empty());
+
+        assert!(bufvec.push(b"second").is_ok());
+        assert_eq!(bufvec.len(), 2);
+
+        assert!(bufvec.push(b"third").is_ok());
+        assert_eq!(bufvec.len(), 3);
+
+        // Verify elements are in correct order (LIFO for stack perspective)
+        assert_eq!(bufvec.get(0), b"first");
+        assert_eq!(bufvec.get(1), b"second");
+        assert_eq!(bufvec.get(2), b"third");
+    }
+
+    #[test]
+    fn test_stack_top_operations() {
+        let mut buffer = [0u8; 200];
+        let mut bufvec = BufVec::with_default_max_slices(&mut buffer).unwrap();
+
+        // Test try_top on empty stack
+        assert!(bufvec.try_top().is_err());
+
+        // Add elements and test top
+        bufvec.push(b"bottom").unwrap();
+        assert_eq!(bufvec.top(), b"bottom");
+        assert_eq!(bufvec.try_top().unwrap(), b"bottom");
+
+        bufvec.push(b"middle").unwrap();
+        assert_eq!(bufvec.top(), b"middle");
+        assert_eq!(bufvec.try_top().unwrap(), b"middle");
+
+        bufvec.push(b"top").unwrap();
+        assert_eq!(bufvec.top(), b"top");
+        assert_eq!(bufvec.try_top().unwrap(), b"top");
+
+        // Verify top doesn't modify the stack
+        assert_eq!(bufvec.len(), 3);
+        assert_eq!(bufvec.top(), b"top");
+    }
+
+    #[test]
+    #[should_panic(expected = "Cannot peek at top of empty stack")]
+    fn test_stack_top_empty_panic() {
+        let mut buffer = [0u8; 200];
+        let bufvec = BufVec::with_default_max_slices(&mut buffer).unwrap();
+        let _ = bufvec.top();
+    }
+
+    #[test]
+    fn test_stack_push_pop_operations() {
+        let mut buffer = [0u8; 200];
+        let mut bufvec = BufVec::with_default_max_slices(&mut buffer).unwrap();
+
+        // Push elements
+        bufvec.push(b"first").unwrap();
+        bufvec.push(b"second").unwrap();
+        bufvec.push(b"third").unwrap();
+
+        assert_eq!(bufvec.len(), 3);
+
+        // Pop elements in LIFO order
+        assert_eq!(bufvec.pop(), b"third");
+        assert_eq!(bufvec.len(), 2);
+        assert_eq!(bufvec.top(), b"second");
+
+        assert_eq!(bufvec.pop(), b"second");
+        assert_eq!(bufvec.len(), 1);
+        assert_eq!(bufvec.top(), b"first");
+
+        assert_eq!(bufvec.pop(), b"first");
+        assert_eq!(bufvec.len(), 0);
+        assert!(bufvec.is_empty());
+
+        // Test error handling
+        assert!(bufvec.try_pop().is_err());
+        assert!(bufvec.try_top().is_err());
+    }
+
+    #[test]
+    fn test_stack_interface_doesnt_break_vector_operations() {
+        let mut buffer = [0u8; 200];
+        let mut bufvec = BufVec::with_default_max_slices(&mut buffer).unwrap();
+
+        // Mix stack and vector operations
+        bufvec.push(b"stack1").unwrap();
+        bufvec.add(b"vector1").unwrap();
+        bufvec.push(b"stack2").unwrap();
+
+        assert_eq!(bufvec.len(), 3);
+        assert_eq!(bufvec.get(0), b"stack1");
+        assert_eq!(bufvec.get(1), b"vector1");
+        assert_eq!(bufvec.get(2), b"stack2");
+
+        // Stack operations still work
+        assert_eq!(bufvec.top(), b"stack2");
+        assert_eq!(bufvec.pop(), b"stack2");
+
+        // Vector operations still work
+        assert_eq!(bufvec.get(0), b"stack1");
+        assert_eq!(bufvec.get(1), b"vector1");
+
+        // Iterator still works
+        let collected: Vec<_> = bufvec.iter().collect();
+        assert_eq!(collected, vec![&b"stack1"[..], &b"vector1"[..]]);
+    }
+
+    #[test]
+    fn test_stack_buffer_overflow() {
+        let mut buffer = [0u8; 150];
+        let mut bufvec = BufVec::with_default_max_slices(&mut buffer).unwrap();
+
+        // Fill buffer to near capacity
+        bufvec.push(b"data1").unwrap();
+        bufvec.push(b"data2").unwrap();
+
+        // Try to push data that won't fit
+        let large_data = vec![b'x'; 100];
+        assert!(bufvec.push(&large_data).is_err());
+
+        // Stack should be unchanged
+        assert_eq!(bufvec.len(), 2);
+        assert_eq!(bufvec.top(), b"data2");
+    }
+
+    #[test]
+    fn test_stack_utility_methods() {
+        let mut buffer = [0u8; 200];
+        let mut bufvec = BufVec::with_default_max_slices(&mut buffer).unwrap();
+
+        // Test utility methods on empty stack
+        assert!(bufvec.is_empty());
+        assert_eq!(bufvec.len(), 0);
+
+        // Add elements and test utilities
+        bufvec.push(b"element").unwrap();
+        assert!(!bufvec.is_empty());
+        assert_eq!(bufvec.len(), 1);
+
+        bufvec.push(b"another").unwrap();
+        assert!(!bufvec.is_empty());
+        assert_eq!(bufvec.len(), 2);
+
+        // Clear and test utilities
+        bufvec.clear();
+        assert!(bufvec.is_empty());
+        assert_eq!(bufvec.len(), 0);
     }
 }


### PR DESCRIPTION
## Summary

- Implement `push()` method as alias for `add()` with stack semantics
- Add `top()` and `try_top()` methods for peeking at last element without removal
- Maintain full compatibility with existing vector and dictionary interfaces
- Add comprehensive test coverage with 7 new test cases covering all stack scenarios
- Update module documentation with stack usage examples and interface patterns

## Test plan

- [x] All existing tests continue to pass (43 total tests)
- [x] New stack interface tests cover: push operations, top operations, push/pop combinations, interface compatibility, buffer overflow, utility methods, and error conditions
- [x] Code passes clippy with no warnings
- [x] Documentation examples compile and work correctly
- [x] Stack interface maintains LIFO semantics while preserving vector functionality

🤖 Generated with [Claude Code](https://claude.ai/code)